### PR TITLE
feat(scry): add limit/offset pagination to listing commands

### DIFF
--- a/crates/fff-cli/src/commands/callees.rs
+++ b/crates/fff-cli/src/commands/callees.rs
@@ -11,15 +11,20 @@ use fff_engine::Engine;
 use fff_symbol::bloom::extract_identifiers;
 
 use crate::cli::OutputFormat;
+use crate::commands::pagination::{footer, Page};
 
 #[derive(Debug, Parser)]
 pub struct Args {
     /// Symbol whose body should be inspected.
     pub name: String,
 
-    /// Maximum number of callees returned.
+    /// Maximum callees returned in this page.
     #[arg(long, default_value_t = 100)]
     pub limit: usize,
+
+    /// Skip this many callees before starting the page.
+    #[arg(long, default_value_t = 0)]
+    pub offset: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -33,6 +38,9 @@ struct CalleeHit {
 struct CalleesOutput {
     name: String,
     hits: Vec<CalleeHit>,
+    total: usize,
+    offset: usize,
+    has_more: bool,
 }
 
 pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
@@ -62,34 +70,33 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
             if ident == args.name {
                 continue;
             }
-            let locs = engine.handles.symbols.lookup_exact(ident);
-            for loc in locs {
+            for loc in engine.handles.symbols.lookup_exact(ident) {
                 hits.push(CalleeHit {
                     name: ident.to_string(),
                     path: loc.path.to_string_lossy().to_string(),
                     line: loc.line,
                 });
-                if hits.len() >= args.limit {
-                    break;
-                }
-            }
-            if hits.len() >= args.limit {
-                break;
             }
         }
     }
 
+    let page = Page::paginate(hits, args.offset, args.limit);
     let payload = CalleesOutput {
         name: args.name,
-        hits,
+        total: page.total,
+        offset: page.offset,
+        has_more: page.has_more,
+        hits: page.items,
     };
     super::emit(format, &payload, |p| {
         let mut out = String::new();
         for h in &p.hits {
             out.push_str(&format!("{} @ {}:{}\n", h.name, h.path, h.line));
         }
-        if p.hits.is_empty() {
+        if p.total == 0 {
             out.push_str("[no callees found]\n");
+        } else {
+            out.push_str(&footer(p.total, p.offset, p.hits.len(), p.has_more));
         }
         out
     })

--- a/crates/fff-cli/src/commands/callers.rs
+++ b/crates/fff-cli/src/commands/callers.rs
@@ -13,15 +13,20 @@ use serde::Serialize;
 use fff_engine::{Engine, PreFilterStack};
 
 use crate::cli::OutputFormat;
+use crate::commands::pagination::{footer, Page};
 
 #[derive(Debug, Parser)]
 pub struct Args {
     /// Symbol name to find call sites for.
     pub name: String,
 
-    /// Maximum total hits returned.
+    /// Maximum hits returned in this page.
     #[arg(long, default_value_t = 100)]
     pub limit: usize,
+
+    /// Skip this many hits before starting the page.
+    #[arg(long, default_value_t = 0)]
+    pub offset: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -35,6 +40,9 @@ struct CallerHit {
 struct CallersOutput {
     name: String,
     hits: Vec<CallerHit>,
+    total: usize,
+    offset: usize,
+    has_more: bool,
 }
 
 pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
@@ -104,26 +112,26 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
                 line: lineno,
                 text: line.to_string(),
             });
-            if hits.len() >= args.limit {
-                break;
-            }
-        }
-        if hits.len() >= args.limit {
-            break;
         }
     }
 
+    let page = Page::paginate(hits, args.offset, args.limit);
     let payload = CallersOutput {
         name: args.name,
-        hits,
+        total: page.total,
+        offset: page.offset,
+        has_more: page.has_more,
+        hits: page.items,
     };
     super::emit(format, &payload, |p| {
         let mut out = String::new();
         for h in &p.hits {
             out.push_str(&format!("{}:{}: {}\n", h.path, h.line, h.text));
         }
-        if p.hits.is_empty() {
+        if p.total == 0 {
             out.push_str("[no callers found]\n");
+        } else {
+            out.push_str(&footer(p.total, p.offset, p.hits.len(), p.has_more));
         }
         out
     })

--- a/crates/fff-cli/src/commands/find.rs
+++ b/crates/fff-cli/src/commands/find.rs
@@ -5,43 +5,57 @@ use clap::Parser;
 use serde::Serialize;
 
 use crate::cli::OutputFormat;
+use crate::commands::pagination::{footer, Page};
 
 #[derive(Debug, Parser)]
 pub struct Args {
     /// Path-substring or fuzzy needle.
     pub needle: String,
 
-    /// Limit number of results emitted.
+    /// Maximum results returned in this page.
     #[arg(long, default_value_t = 50)]
     pub limit: usize,
+
+    /// Skip this many results before starting the page.
+    #[arg(long, default_value_t = 0)]
+    pub offset: usize,
 }
 
 #[derive(Debug, Serialize)]
 struct FindResult {
     needle: String,
     matches: Vec<String>,
+    total: usize,
+    offset: usize,
+    has_more: bool,
 }
 
 pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
     let files = super::walk_files(root);
     let needle_lower = args.needle.to_lowercase();
-    let mut matches: Vec<String> = files
+    let mut all: Vec<String> = files
         .iter()
         .filter_map(|p| p.to_str().map(|s| s.to_string()))
         .filter(|p| p.to_lowercase().contains(&needle_lower))
-        .take(args.limit)
         .collect();
-    matches.sort();
+    all.sort();
 
+    let page = Page::paginate(all, args.offset, args.limit);
     let payload = FindResult {
         needle: args.needle,
-        matches,
+        total: page.total,
+        offset: page.offset,
+        has_more: page.has_more,
+        matches: page.items,
     };
     super::emit(format, &payload, |p| {
         let mut out = String::new();
         for m in &p.matches {
             out.push_str(m);
             out.push('\n');
+        }
+        if p.total > 0 {
+            out.push_str(&footer(p.total, p.offset, p.matches.len(), p.has_more));
         }
         out
     })

--- a/crates/fff-cli/src/commands/mod.rs
+++ b/crates/fff-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod glob;
 pub mod grep;
 pub mod index;
 pub mod mcp;
+pub(crate) mod pagination;
 pub mod read;
 pub mod symbol;
 

--- a/crates/fff-cli/src/commands/pagination.rs
+++ b/crates/fff-cli/src/commands/pagination.rs
@@ -1,0 +1,153 @@
+// Limit/offset windowing for command outputs (callers, callees, symbol, find).
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct Page<T> {
+    pub items: Vec<T>,
+    pub total: usize,
+    pub offset: usize,
+    pub has_more: bool,
+}
+
+impl<T> Page<T> {
+    // offset >= total → empty page; limit == 0 → empty page but has_more if anything
+    // remained after offset; otherwise drain offset, truncate to limit.
+    pub fn paginate(mut all: Vec<T>, offset: usize, limit: usize) -> Self {
+        let total = all.len();
+        if offset >= total {
+            return Self {
+                items: Vec::new(),
+                total,
+                offset,
+                has_more: false,
+            };
+        }
+        all.drain(..offset);
+        if limit == 0 {
+            return Self {
+                items: Vec::new(),
+                total,
+                offset,
+                has_more: !all.is_empty(),
+            };
+        }
+        let has_more = all.len() > limit;
+        if has_more {
+            all.truncate(limit);
+        }
+        Self {
+            items: all,
+            total,
+            offset,
+            has_more,
+        }
+    }
+}
+
+// One-line "[start-end of total]" footer for human text output. `returned`
+// is the number of items shown on this page (separated from `Page<T>` so the
+// caller can borrow individual fields without keeping the page itself around).
+pub(crate) fn footer(total: usize, offset: usize, returned: usize, has_more: bool) -> String {
+    if total == 0 {
+        return String::new();
+    }
+    let end = offset.saturating_add(returned);
+    let mut out = format!("[{}-{} of {}]", offset + 1, end, total);
+    if has_more {
+        let next = offset.saturating_add(returned);
+        out.push_str(&format!(" — next: --offset {next}"));
+    }
+    out.push('\n');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{footer, Page};
+
+    #[test]
+    fn first_page_with_limit_smaller_than_total() {
+        let p = Page::paginate(vec![1, 2, 3, 4, 5], 0, 3);
+        assert_eq!(p.items, vec![1, 2, 3]);
+        assert_eq!(p.total, 5);
+        assert_eq!(p.offset, 0);
+        assert!(p.has_more);
+        assert_eq!(p.items.len(), 3);
+    }
+
+    #[test]
+    fn middle_page_via_offset() {
+        let p = Page::paginate(vec![1, 2, 3, 4, 5, 6], 2, 2);
+        assert_eq!(p.items, vec![3, 4]);
+        assert_eq!(p.total, 6);
+        assert_eq!(p.offset, 2);
+        assert!(p.has_more);
+    }
+
+    #[test]
+    fn last_page_clears_has_more() {
+        let p = Page::paginate(vec![1, 2, 3], 1, 10);
+        assert_eq!(p.items, vec![2, 3]);
+        assert_eq!(p.total, 3);
+        assert!(!p.has_more);
+    }
+
+    #[test]
+    fn offset_past_end_returns_empty_no_more() {
+        let p: Page<i32> = Page::paginate(vec![1, 2, 3], 10, 5);
+        assert!(p.items.is_empty());
+        assert_eq!(p.total, 3);
+        assert_eq!(p.offset, 10);
+        assert!(!p.has_more);
+    }
+
+    #[test]
+    fn empty_input_is_empty_page() {
+        let p: Page<i32> = Page::paginate(Vec::new(), 0, 10);
+        assert!(p.items.is_empty());
+        assert_eq!(p.total, 0);
+        assert!(!p.has_more);
+    }
+
+    #[test]
+    fn limit_zero_signals_more_when_anything_left() {
+        let p = Page::paginate(vec![1, 2, 3], 1, 0);
+        assert!(p.items.is_empty());
+        assert_eq!(p.total, 3);
+        assert_eq!(p.offset, 1);
+        assert!(p.has_more);
+    }
+
+    #[test]
+    fn limit_equal_to_remaining_clears_has_more() {
+        let p = Page::paginate(vec![1, 2, 3, 4], 1, 3);
+        assert_eq!(p.items, vec![2, 3, 4]);
+        assert!(!p.has_more);
+    }
+
+    #[test]
+    fn footer_renders_range_and_next_offset() {
+        let s = footer(10, 0, 3, true);
+        assert!(s.starts_with("[1-3 of 10]"));
+        assert!(s.contains("--offset 3"));
+    }
+
+    #[test]
+    fn footer_omits_next_when_no_more() {
+        let s = footer(3, 0, 3, false);
+        assert!(s.starts_with("[1-3 of 3]"));
+        assert!(!s.contains("--offset"));
+    }
+
+    #[test]
+    fn footer_empty_when_total_zero() {
+        assert!(footer(0, 0, 0, false).is_empty());
+    }
+
+    #[test]
+    fn footer_offset_at_end_shows_empty_range() {
+        let s = footer(5, 5, 0, false);
+        assert!(s.starts_with("[6-5 of 5]") || s.contains("of 5"));
+    }
+}

--- a/crates/fff-cli/src/commands/symbol.rs
+++ b/crates/fff-cli/src/commands/symbol.rs
@@ -8,17 +8,29 @@ use fff_engine::Engine;
 use fff_symbol::symbol_index::SymbolLocation;
 
 use crate::cli::OutputFormat;
+use crate::commands::pagination::{footer, Page};
 
 #[derive(Debug, Parser)]
 pub struct Args {
     /// Symbol name to look up. Glob patterns ending with `*` are treated as prefixes.
     pub name: String,
+
+    /// Maximum hits returned in this page.
+    #[arg(long, default_value_t = 100)]
+    pub limit: usize,
+
+    /// Skip this many hits before starting the page.
+    #[arg(long, default_value_t = 0)]
+    pub offset: usize,
 }
 
 #[derive(Debug, Serialize)]
 struct SymbolOutput {
     query: String,
     hits: Vec<SymbolHit>,
+    total: usize,
+    offset: usize,
+    has_more: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -46,7 +58,7 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
     let engine = Engine::default();
     engine.index(root);
 
-    let hits: Vec<SymbolHit> = if let Some(prefix) = args.name.strip_suffix('*') {
+    let all_hits: Vec<SymbolHit> = if let Some(prefix) = args.name.strip_suffix('*') {
         engine
             .handles
             .symbols
@@ -64,9 +76,13 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
             .collect()
     };
 
+    let page = Page::paginate(all_hits, args.offset, args.limit);
     let payload = SymbolOutput {
         query: args.name,
-        hits,
+        total: page.total,
+        offset: page.offset,
+        has_more: page.has_more,
+        hits: page.items,
     };
     super::emit(format, &payload, |p| {
         let mut out = String::new();
@@ -76,8 +92,10 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
                 h.name, h.path, h.line, h.kind
             ));
         }
-        if p.hits.is_empty() {
+        if p.total == 0 {
             out.push_str("[no symbols found]\n");
+        } else {
+            out.push_str(&footer(p.total, p.offset, p.hits.len(), p.has_more));
         }
         out
     })

--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -1,5 +1,5 @@
 *fff.nvim.txt*
-                              For Neovim >= 0.10.0    Last change: 2026 May 09
+                              For Neovim >= 0.10.0    Last change: 2026 May 10
 
 ==============================================================================
 Table of Contents                                 *fff.nvim-table-of-contents*


### PR DESCRIPTION
## Summary

Adds a small `Page<T>` helper used by the listing sub-commands (`callers`, `callees`, `symbol`, `find`) so callers can deterministically walk through large result sets without re-running the underlying scan.

**What changed**

- New `crates/fff-cli/src/commands/pagination.rs` (~150 LOC) with:
  - `Page<T>` — `{ items, total, offset, has_more }`
  - `Page::paginate(all, offset, limit)` — drains `offset`, truncates to `limit`, sets `has_more`
  - `footer(total, offset, returned, has_more)` — renders `[start-end of total] — next: --offset N` for human text output
  - 11 unit tests covering edge cases (empty input, offset past end, last page, `limit=0`, etc.)
- `callers`, `callees`, `symbol`, `find` now:
  - Accept `--offset` (default `0`) alongside the existing `--limit`
  - Emit `total`, `offset`, `has_more` in their JSON payload
  - Print a one-line `[start-end of total] — next: --offset N` footer in text output (omitted when no results)
- `commands/mod.rs` registers the new `pagination` module as `pub(crate)`

**Smoke test**

```
$ scry --root crates/fff-cli/src find rs --limit 3
crates/fff-cli/src/cli.rs
crates/fff-cli/src/commands/callees.rs
crates/fff-cli/src/commands/callers.rs
[1-3 of 14] — next: --offset 3

$ scry --root crates/fff-cli/src find rs --limit 3 --offset 3
crates/fff-cli/src/commands/dispatch.rs
crates/fff-cli/src/commands/find.rs
crates/fff-cli/src/commands/glob.rs
[4-6 of 14] — next: --offset 6

$ scry --format json --root crates/fff-cli/src find rs --limit 2
{
  "needle": "rs",
  "matches": ["...cli.rs", "...callees.rs"],
  "total": 14,
  "offset": 0,
  "has_more": true
}
```

`cargo build -p fff-cli`, `cargo clippy -p fff-cli -- -D warnings`, `cargo fmt --check`, and `cargo test -p fff-cli` (11 tests) all pass.

## Review & Testing Checklist for Human

- [ ] Confirm the JSON shape (`total`, `offset`, `has_more` added alongside the existing `hits`/`matches` field) is acceptable as an additive change for any downstream JSON consumers — none are known in this repo, but flagging for review.
- [ ] Confirm the text-output footer format `[start-end of total] — next: --offset N` reads well; alternative would be a quieter `... and N more` style.
- [ ] Verify CLI arg defaults (`--offset 0`, existing `--limit` defaults preserved) match expectations for each command.

### Notes

- All four commands share the same `Page<T>` helper; future listing commands (e.g. a future `deps`) can drop in the same pattern.
- `limit=0` is handled as a no-results page that still reports `has_more=true` when more results exist after the offset, so callers can use it to ask "is there more?" without paying the per-item cost.
- No changes to public APIs in `fff-symbol`, `fff-engine`, or `fff-budget` — pagination lives entirely inside `fff-cli`.
