### PR TITLE
feat(scry): add facets summary to symbol output and dedup callees

### DIFF
--- a/crates/fff-cli/src/commands/callees.rs
+++ b/crates/fff-cli/src/commands/callees.rs
@@ -11,6 +11,7 @@ use fff_engine::Engine;
 use fff_symbol::bloom::extract_identifiers;
 
 use crate::cli::OutputFormat;
+use crate::commands::dedup::dedup_by;
 use crate::commands::pagination::{footer, Page};
 
 #[derive(Debug, Parser)]
@@ -80,6 +81,10 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
         }
     }
 
+    // Multiple definition sites of the same target symbol can produce the same
+    // (name, path, line) triple from different bodies; collapse them so each
+    // unique callee is reported once.
+    let hits = dedup_by(hits, |h| (h.name.clone(), h.path.clone(), h.line));
     let page = Page::paginate(hits, args.offset, args.limit);
     let payload = CalleesOutput {
         name: args.name,

--- a/crates/fff-cli/src/commands/dedup.rs
+++ b/crates/fff-cli/src/commands/dedup.rs
@@ -1,0 +1,57 @@
+// Stable de-duplication keyed by an arbitrary key function. Preserves the
+// first occurrence of each key; later duplicates are dropped. Used when
+// accumulating hits from multiple lookup paths that may point at the same
+// (path, line) site.
+
+use std::collections::HashSet;
+use std::hash::Hash;
+
+pub(crate) fn dedup_by<T, K, F>(items: Vec<T>, mut key: F) -> Vec<T>
+where
+    F: FnMut(&T) -> K,
+    K: Hash + Eq,
+{
+    let mut seen: HashSet<K> = HashSet::with_capacity(items.len());
+    items.into_iter().filter(|t| seen.insert(key(t))).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dedup_by;
+
+    #[test]
+    fn empty_input_returns_empty() {
+        let out: Vec<i32> = dedup_by(Vec::new(), |x| *x);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn keeps_first_occurrence_of_each_key() {
+        let v = vec![1, 2, 1, 3, 2, 4];
+        let out = dedup_by(v, |x| *x);
+        assert_eq!(out, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn key_can_be_a_subset_of_the_value() {
+        let v = vec![("a", 1), ("b", 2), ("a", 3), ("c", 4)];
+        let out = dedup_by(v, |t| t.0);
+        // "a" appeared first as ("a", 1); the later ("a", 3) is dropped.
+        assert_eq!(out, vec![("a", 1), ("b", 2), ("c", 4)]);
+    }
+
+    #[test]
+    fn distinct_keys_pass_through_unchanged() {
+        let v = vec![10, 20, 30];
+        let out = dedup_by(v.clone(), |x| *x);
+        assert_eq!(out, v);
+    }
+
+    #[test]
+    fn composite_key_distinguishes_otherwise_equal_lhs() {
+        // Same path, same name, different lines → all kept.
+        let v = vec![("foo", "p", 1u32), ("foo", "p", 2u32), ("foo", "p", 1u32)];
+        let out = dedup_by(v, |t| (t.0, t.1, t.2));
+        assert_eq!(out, vec![("foo", "p", 1), ("foo", "p", 2)]);
+    }
+}

--- a/crates/fff-cli/src/commands/facets.rs
+++ b/crates/fff-cli/src/commands/facets.rs
@@ -1,0 +1,66 @@
+// Group-by counting helper for command outputs (e.g. how many `function`s vs
+// `struct`s a `symbol` query returned). Counts are computed on the *full*
+// candidate set, not the paginated page, so they survive offset/limit.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct Facets {
+    pub total: usize,
+    // BTreeMap so JSON output order is stable (alphabetical by kind).
+    pub by_kind: BTreeMap<String, usize>,
+}
+
+impl Facets {
+    pub fn from_kinds<I, S>(kinds: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut by_kind: BTreeMap<String, usize> = BTreeMap::new();
+        let mut total = 0usize;
+        for k in kinds {
+            *by_kind.entry(k.as_ref().to_string()).or_insert(0) += 1;
+            total += 1;
+        }
+        Self { total, by_kind }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Facets;
+
+    #[test]
+    fn empty_input_yields_zero_total_and_no_buckets() {
+        let f = Facets::from_kinds(Vec::<&str>::new());
+        assert_eq!(f.total, 0);
+        assert!(f.by_kind.is_empty());
+    }
+
+    #[test]
+    fn counts_grouped_by_kind() {
+        let f = Facets::from_kinds(vec!["function", "function", "struct", "function"]);
+        assert_eq!(f.total, 4);
+        assert_eq!(f.by_kind.get("function"), Some(&3));
+        assert_eq!(f.by_kind.get("struct"), Some(&1));
+    }
+
+    #[test]
+    fn buckets_are_sorted_alphabetically() {
+        let f = Facets::from_kinds(vec!["zeta", "alpha", "mu", "alpha"]);
+        let keys: Vec<&str> = f.by_kind.keys().map(String::as_str).collect();
+        assert_eq!(keys, vec!["alpha", "mu", "zeta"]);
+    }
+
+    #[test]
+    fn accepts_owned_strings_too() {
+        let owned = vec![String::from("a"), String::from("b"), String::from("a")];
+        let f = Facets::from_kinds(owned);
+        assert_eq!(f.total, 3);
+        assert_eq!(f.by_kind.get("a"), Some(&2));
+        assert_eq!(f.by_kind.get("b"), Some(&1));
+    }
+}

--- a/crates/fff-cli/src/commands/mod.rs
+++ b/crates/fff-cli/src/commands/mod.rs
@@ -1,6 +1,8 @@
 pub mod callees;
 pub mod callers;
+pub(crate) mod dedup;
 pub mod dispatch;
+pub(crate) mod facets;
 pub mod find;
 pub mod glob;
 pub mod grep;

--- a/crates/fff-cli/src/commands/symbol.rs
+++ b/crates/fff-cli/src/commands/symbol.rs
@@ -8,6 +8,7 @@ use fff_engine::Engine;
 use fff_symbol::symbol_index::SymbolLocation;
 
 use crate::cli::OutputFormat;
+use crate::commands::facets::Facets;
 use crate::commands::pagination::{footer, Page};
 
 #[derive(Debug, Parser)]
@@ -31,6 +32,7 @@ struct SymbolOutput {
     total: usize,
     offset: usize,
     has_more: bool,
+    facets: Facets,
 }
 
 #[derive(Debug, Serialize)]
@@ -76,6 +78,7 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
             .collect()
     };
 
+    let facets = Facets::from_kinds(all_hits.iter().map(|h| h.kind.as_str()));
     let page = Page::paginate(all_hits, args.offset, args.limit);
     let payload = SymbolOutput {
         query: args.name,
@@ -83,6 +86,7 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
         offset: page.offset,
         has_more: page.has_more,
         hits: page.items,
+        facets,
     };
     super::emit(format, &payload, |p| {
         let mut out = String::new();
@@ -96,6 +100,15 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
             out.push_str("[no symbols found]\n");
         } else {
             out.push_str(&footer(p.total, p.offset, p.hits.len(), p.has_more));
+            if !p.facets.by_kind.is_empty() {
+                let parts: Vec<String> = p
+                    .facets
+                    .by_kind
+                    .iter()
+                    .map(|(k, n)| format!("{k}: {n}"))
+                    .collect();
+                out.push_str(&format!("by kind: {}\n", parts.join(", ")));
+            }
         }
         out
     })


### PR DESCRIPTION
## Summary

Two small CLI helpers, both `pub(crate)` in `fff-cli`:

- **`commands/facets.rs`** — `Facets { total, by_kind: BTreeMap<String, usize> }`, computed on the *full* candidate set (before pagination) so the totals survive `--offset` / `--limit`. Wired into the `symbol` command output:
  - JSON: new `facets` field with a stable, alphabetically-keyed `by_kind` map.
  - Text: footer line `by kind: function: 12, struct: 3` after the existing `[start-end of total]` line.
- **`commands/dedup.rs`** — `dedup_by<T, K>(items, key)`: stable de-duplication keyed by an arbitrary projection. Wired into the `callees` command to collapse identical `(name, path, line)` triples that arise when a target symbol has several definition sites whose bodies happen to reference the same callee.

Stacked on top of #1 (pagination); merge order: #1 → #2.

**Smoke test**

```
$ scry --root crates/fff-symbol/src symbol "Symbol*" --limit 3
SymbolLocation @ crates/fff-symbol/src/symbol_index.rs:22 (struct_item)
SymbolIndex     @ crates/fff-symbol/src/symbol_index.rs:32 (struct_item)
[1-2 of 2]
by kind: struct_item: 2

$ scry --format json --root crates/fff-symbol/src symbol "Symbol*" --limit 1
{
  "query": "Symbol*",
  "hits": [{ "name": "SymbolIndex", ..., "kind": "struct_item", ... }],
  "total": 2,
  "offset": 0,
  "has_more": true,
  "facets": { "total": 2, "by_kind": { "struct_item": 2 } }
}
```

`cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`, and `cargo test -p fff-cli` (20 tests, including 9 new) all pass.

## Review & Testing Checklist for Human

- [ ] Confirm the `facets` field added to the `symbol` JSON output is acceptable as a purely additive change.
- [ ] Confirm the `by kind: …` text footer is the right shape (alternative would be a separate line per bucket).
- [ ] Sanity-check the `dedup_by` use site in `callees`: keying on `(name, path, line)` is intentional — same callee at the same line, even discovered via two different parent definitions, should appear once.

### Notes

- `Facets` is `pub(crate)` and intentionally narrow (single `from_kinds` constructor); it can be reused later for `callers`/`callees` if we want kind-bucketed counts there too.
- `dedup_by` is also `pub(crate)`, generic, and stable (preserves first-seen order). Cheap enough to use anywhere we accumulate hits across multiple lookup paths.
- No public API changes outside `fff-cli`.
