### PR TITLE
feat(scry): add outline subcommand with markdown/structured/tabular renderers

### DIFF
--- a/crates/fff-cli/src/cli.rs
+++ b/crates/fff-cli/src/cli.rs
@@ -48,6 +48,9 @@ pub enum Command {
     /// Read a file with token-budget aware truncation (replaces `cat`).
     Read(commands::read::Args),
 
+    /// Render a file's structural outline (functions, classes, …).
+    Outline(commands::outline::Args),
+
     /// Look up symbol definitions (NEW; tree-sitter AST powered).
     Symbol(commands::symbol::Args),
 
@@ -79,6 +82,7 @@ impl Cli {
             Command::Glob(a) => commands::glob::run(a, &root, self.format),
             Command::Grep(a) => commands::grep::run(a, &root, self.format),
             Command::Read(a) => commands::read::run(a, &root, self.format),
+            Command::Outline(a) => commands::outline::run(a, &root, self.format),
             Command::Symbol(a) => commands::symbol::run(a, &root, self.format),
             Command::Callers(a) => commands::callers::run(a, &root, self.format),
             Command::Callees(a) => commands::callees::run(a, &root, self.format),

--- a/crates/fff-cli/src/commands/mod.rs
+++ b/crates/fff-cli/src/commands/mod.rs
@@ -8,6 +8,8 @@ pub mod glob;
 pub mod grep;
 pub mod index;
 pub mod mcp;
+pub mod outline;
+pub(crate) mod outline_format;
 pub(crate) mod pagination;
 pub mod read;
 pub mod symbol;

--- a/crates/fff-cli/src/commands/outline.rs
+++ b/crates/fff-cli/src/commands/outline.rs
@@ -1,0 +1,109 @@
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+use clap::{Parser, ValueEnum};
+use serde::Serialize;
+
+use fff_symbol::lang::detect_file_type;
+use fff_symbol::outline::get_outline_entries;
+use fff_symbol::types::{FileType, OutlineEntry, OutlineKind};
+
+use crate::cli::OutputFormat;
+use crate::commands::outline_format;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum Style {
+    Markdown,
+    Structured,
+    Tabular,
+}
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// File to outline.
+    pub path: String,
+
+    /// Text rendering style. Ignored when --format=json.
+    #[arg(long, value_enum, default_value_t = Style::Tabular)]
+    pub style: Style,
+}
+
+#[derive(Debug, Serialize)]
+struct OutlineOutput {
+    path: String,
+    lang: String,
+    entries: Vec<OutlineEntryDto>,
+}
+
+#[derive(Debug, Serialize)]
+struct OutlineEntryDto {
+    kind: String,
+    name: String,
+    start_line: u32,
+    end_line: u32,
+    signature: Option<String>,
+    children: Vec<OutlineEntryDto>,
+}
+
+impl OutlineEntryDto {
+    fn from_entry(e: &OutlineEntry) -> Self {
+        Self {
+            kind: kind_str(e.kind).to_string(),
+            name: e.name.clone(),
+            start_line: e.start_line,
+            end_line: e.end_line,
+            signature: e.signature.clone(),
+            children: e.children.iter().map(Self::from_entry).collect(),
+        }
+    }
+}
+
+fn kind_str(k: OutlineKind) -> &'static str {
+    match k {
+        OutlineKind::Import => "import",
+        OutlineKind::Function => "function",
+        OutlineKind::Class => "class",
+        OutlineKind::Struct => "struct",
+        OutlineKind::Interface => "interface",
+        OutlineKind::TypeAlias => "type_alias",
+        OutlineKind::Enum => "enum",
+        OutlineKind::Constant => "constant",
+        OutlineKind::Variable => "variable",
+        OutlineKind::ImmutableVariable => "immutable_variable",
+        OutlineKind::Export => "export",
+        OutlineKind::Property => "property",
+        OutlineKind::Module => "module",
+        OutlineKind::TestSuite => "test_suite",
+        OutlineKind::TestCase => "test_case",
+    }
+}
+
+pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
+    let p = if Path::new(&args.path).is_absolute() {
+        std::path::PathBuf::from(&args.path)
+    } else {
+        root.join(&args.path)
+    };
+
+    let ft = detect_file_type(&p);
+    let lang = match ft {
+        FileType::Code(l) => l,
+        _ => return Err(anyhow!("not a code file: {}", p.display())),
+    };
+
+    let content =
+        std::fs::read_to_string(&p).map_err(|e| anyhow!("failed to read {}: {e}", p.display()))?;
+    let entries = get_outline_entries(&content, lang);
+
+    let payload = OutlineOutput {
+        path: p.to_string_lossy().to_string(),
+        lang: format!("{lang:?}"),
+        entries: entries.iter().map(OutlineEntryDto::from_entry).collect(),
+    };
+
+    super::emit(format, &payload, |_| match args.style {
+        Style::Markdown => outline_format::markdown(&entries),
+        Style::Structured => outline_format::structured(&entries),
+        Style::Tabular => outline_format::tabular(&entries),
+    })
+}

--- a/crates/fff-cli/src/commands/outline_format.rs
+++ b/crates/fff-cli/src/commands/outline_format.rs
@@ -1,0 +1,301 @@
+// Three text renderings of an outline tree:
+//
+// * markdown — nested bullet list, `- kind ` ``name`` ` (start-end)`
+// * structured — ASCII tree with ├─ / └─ branch glyphs
+// * tabular — fixed-width columns: KIND, NAME, LINES, SIGNATURE
+//
+// All three accept the same `&[OutlineEntry]` and return a `String` that
+// always ends with a trailing newline (or is empty).
+
+use fff_symbol::types::{OutlineEntry, OutlineKind};
+
+pub(crate) fn markdown(entries: &[OutlineEntry]) -> String {
+    let mut out = String::new();
+    for e in entries {
+        push_markdown(&mut out, e, 0);
+    }
+    out
+}
+
+fn push_markdown(out: &mut String, e: &OutlineEntry, depth: usize) {
+    let indent = "  ".repeat(depth);
+    out.push_str(&indent);
+    out.push_str("- ");
+    out.push_str(kind_label(e.kind));
+    out.push(' ');
+    out.push('`');
+    out.push_str(&e.name);
+    out.push('`');
+    out.push_str(&format!(" ({}-{})\n", e.start_line, e.end_line));
+    if let Some(sig) = e.signature.as_ref() {
+        if !sig.is_empty() {
+            out.push_str(&"  ".repeat(depth + 1));
+            out.push_str("- `");
+            out.push_str(sig);
+            out.push_str("`\n");
+        }
+    }
+    for c in &e.children {
+        push_markdown(out, c, depth + 1);
+    }
+}
+
+pub(crate) fn structured(entries: &[OutlineEntry]) -> String {
+    let mut out = String::new();
+    let n = entries.len();
+    for (i, e) in entries.iter().enumerate() {
+        push_structured(&mut out, e, "", i + 1 == n);
+    }
+    out
+}
+
+fn push_structured(out: &mut String, e: &OutlineEntry, prefix: &str, is_last: bool) {
+    let branch = if is_last { "└─ " } else { "├─ " };
+    out.push_str(prefix);
+    out.push_str(branch);
+    out.push_str(kind_label(e.kind));
+    out.push_str(": ");
+    out.push_str(&e.name);
+    out.push_str(&format!(" ({}-{})\n", e.start_line, e.end_line));
+
+    let child_prefix = format!("{prefix}{}", if is_last { "   " } else { "│  " });
+    let n = e.children.len();
+    for (i, c) in e.children.iter().enumerate() {
+        push_structured(out, c, &child_prefix, i + 1 == n);
+    }
+}
+
+pub(crate) fn tabular(entries: &[OutlineEntry]) -> String {
+    let mut rows: Vec<(String, String, String, String)> = Vec::new();
+    for e in entries {
+        push_tabular_rows(e, 0, &mut rows);
+    }
+    if rows.is_empty() {
+        return String::new();
+    }
+    // Compute column widths (cap NAME so very long identifiers don't blow up
+    // the layout; signatures are emitted as-is, last column).
+    let header = (
+        "KIND".to_string(),
+        "NAME".to_string(),
+        "LINES".to_string(),
+        "SIGNATURE".to_string(),
+    );
+    let mut all = vec![header];
+    all.extend(rows);
+    let kw = all.iter().map(|r| r.0.len()).max().unwrap_or(4);
+    let nw = all.iter().map(|r| r.1.len()).max().unwrap_or(4).min(40);
+    let lw = all.iter().map(|r| r.2.len()).max().unwrap_or(5);
+
+    let mut out = String::new();
+    for (k, n, l, s) in &all {
+        out.push_str(&format!(
+            "{:<kw$}  {:<nw$}  {:<lw$}  {}\n",
+            k,
+            truncate(n, nw),
+            l,
+            s,
+            kw = kw,
+            nw = nw,
+            lw = lw,
+        ));
+    }
+    out
+}
+
+fn push_tabular_rows(
+    e: &OutlineEntry,
+    depth: usize,
+    out: &mut Vec<(String, String, String, String)>,
+) {
+    let kind = kind_label(e.kind).to_string();
+    let name = if depth == 0 {
+        e.name.clone()
+    } else {
+        format!("{}{}", "  ".repeat(depth), e.name)
+    };
+    let lines = format!("{}-{}", e.start_line, e.end_line);
+    let sig = e.signature.clone().unwrap_or_default();
+    out.push((kind, name, lines, sig));
+    for c in &e.children {
+        push_tabular_rows(c, depth + 1, out);
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut taken: String = s.chars().take(max.saturating_sub(1)).collect();
+    taken.push('…');
+    taken
+}
+
+fn kind_label(k: OutlineKind) -> &'static str {
+    match k {
+        OutlineKind::Import => "import",
+        OutlineKind::Function => "function",
+        OutlineKind::Class => "class",
+        OutlineKind::Struct => "struct",
+        OutlineKind::Interface => "interface",
+        OutlineKind::TypeAlias => "type",
+        OutlineKind::Enum => "enum",
+        OutlineKind::Constant => "const",
+        OutlineKind::Variable => "var",
+        OutlineKind::ImmutableVariable => "let",
+        OutlineKind::Export => "export",
+        OutlineKind::Property => "property",
+        OutlineKind::Module => "module",
+        OutlineKind::TestSuite => "test_suite",
+        OutlineKind::TestCase => "test",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{kind_label, markdown, structured, tabular};
+    use fff_symbol::types::{OutlineEntry, OutlineKind};
+
+    fn entry(kind: OutlineKind, name: &str, start: u32, end: u32) -> OutlineEntry {
+        OutlineEntry {
+            kind,
+            name: name.to_string(),
+            start_line: start,
+            end_line: end,
+            signature: None,
+            children: Vec::new(),
+            doc: None,
+        }
+    }
+
+    fn entry_with_sig(
+        kind: OutlineKind,
+        name: &str,
+        start: u32,
+        end: u32,
+        sig: &str,
+    ) -> OutlineEntry {
+        let mut e = entry(kind, name, start, end);
+        e.signature = Some(sig.to_string());
+        e
+    }
+
+    #[test]
+    fn markdown_empty_input_is_empty_string() {
+        let out = markdown(&[]);
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn markdown_renders_top_level_entries() {
+        let entries = vec![
+            entry(OutlineKind::Function, "main", 12, 50),
+            entry(OutlineKind::Struct, "Config", 5, 10),
+        ];
+        let out = markdown(&entries);
+        assert_eq!(out, "- function `main` (12-50)\n- struct `Config` (5-10)\n");
+    }
+
+    #[test]
+    fn markdown_indents_children_and_includes_signature() {
+        let mut parent = entry_with_sig(OutlineKind::Function, "outer", 1, 20, "fn outer()");
+        parent
+            .children
+            .push(entry(OutlineKind::Function, "inner", 5, 10));
+        let out = markdown(&[parent]);
+        assert_eq!(
+            out,
+            "- function `outer` (1-20)\n  - `fn outer()`\n  - function `inner` (5-10)\n"
+        );
+    }
+
+    #[test]
+    fn structured_uses_branches_and_marks_last_child() {
+        let mut parent = entry(OutlineKind::Class, "Foo", 1, 30);
+        parent
+            .children
+            .push(entry(OutlineKind::Function, "a", 2, 5));
+        parent
+            .children
+            .push(entry(OutlineKind::Function, "b", 6, 10));
+        let other = entry(OutlineKind::Struct, "Bar", 35, 40);
+        let out = structured(&[parent, other]);
+        let expected = "\
+├─ class: Foo (1-30)\n\
+│  ├─ function: a (2-5)\n\
+│  └─ function: b (6-10)\n\
+└─ struct: Bar (35-40)\n";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn structured_empty_input_is_empty_string() {
+        let out = structured(&[]);
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn tabular_renders_header_and_padded_columns() {
+        let entries = vec![
+            entry_with_sig(OutlineKind::Function, "main", 12, 50, "fn main()"),
+            entry(OutlineKind::Struct, "Config", 5, 10),
+        ];
+        let out = tabular(&entries);
+        // Header row must be present and aligned with the data rows.
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].starts_with("KIND"));
+        assert!(lines[0].contains("NAME"));
+        assert!(lines[0].contains("LINES"));
+        assert!(lines[0].contains("SIGNATURE"));
+        assert!(lines[1].contains("function"));
+        assert!(lines[1].contains("main"));
+        assert!(lines[1].contains("12-50"));
+        assert!(lines[1].contains("fn main()"));
+        assert!(lines[2].contains("struct"));
+        assert!(lines[2].contains("Config"));
+        assert!(lines[2].contains("5-10"));
+    }
+
+    #[test]
+    fn tabular_empty_input_is_empty_string() {
+        assert_eq!(tabular(&[]), "");
+    }
+
+    #[test]
+    fn tabular_indents_child_names_so_hierarchy_is_visible() {
+        let mut parent = entry(OutlineKind::Class, "Cls", 1, 20);
+        parent
+            .children
+            .push(entry(OutlineKind::Property, "field", 2, 2));
+        let out = tabular(&[parent]);
+        // Child name should be prefixed with two spaces of indent.
+        assert!(out.contains("  field"));
+    }
+
+    #[test]
+    fn kind_label_covers_every_variant() {
+        // Sanity: just call it on every variant; the test is that the match
+        // is exhaustive (compile-time) and that no label is empty.
+        let all = [
+            OutlineKind::Import,
+            OutlineKind::Function,
+            OutlineKind::Class,
+            OutlineKind::Struct,
+            OutlineKind::Interface,
+            OutlineKind::TypeAlias,
+            OutlineKind::Enum,
+            OutlineKind::Constant,
+            OutlineKind::Variable,
+            OutlineKind::ImmutableVariable,
+            OutlineKind::Export,
+            OutlineKind::Property,
+            OutlineKind::Module,
+            OutlineKind::TestSuite,
+            OutlineKind::TestCase,
+        ];
+        for k in all {
+            assert!(!kind_label(k).is_empty());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

New `scry outline <file>` subcommand renders a file's structural outline (functions, classes, structs, imports, …) using `fff-symbol`'s existing tree-sitter `get_outline_entries`.

Three text styles via `--style` (default: `tabular`):

- **tabular** — fixed-width `KIND / NAME / LINES / SIGNATURE` columns. Child names are indented by depth so hierarchy is still visible.
- **markdown** — nested bullet list with backticked names and signatures, e.g. `` - function `main` (12-50) ``.
- **structured** — ASCII tree with `├─` / `└─` branch glyphs, last-child aware so the rightmost branch closes correctly.

JSON output (`--format json`) emits a serialisable mirror of the entry tree (`kind`, `name`, `start_line`, `end_line`, `signature`, `children`) regardless of `--style`.

Stacked on top of #2 (facets+dedup) → #1 (pagination). Merge order: #1 → #2 → #3.

**Smoke test**

```
$ scry outline crates/fff-cli/src/commands/find.rs
KIND      NAME         LINES  SIGNATURE
import    <anonymous>  1-1    use std::path::Path;
import    <anonymous>  3-3    use anyhow::Result;
…
struct    Args         11-22  pub struct Args {
struct    FindResult   25-31  struct FindResult {
function  run          33-62  pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {

$ scry outline crates/fff-cli/src/commands/find.rs --style structured
├─ import: <anonymous> (1-1)
├─ struct: Args (11-22)
├─ struct: FindResult (25-31)
└─ function: run (33-62)

$ scry outline crates/fff-cli/src/commands/find.rs --style markdown
- struct `Args` (11-22)
  - `pub struct Args {`
- function `run` (33-62)
  - `pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {`
```

`cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`, and `cargo test -p fff-cli` (29 tests, 9 new) are all clean.

## Review & Testing Checklist for Human

- [ ] Confirm the chosen default style (`tabular`) matches the intended UX. The other two are one flag away.
- [ ] Confirm the JSON shape (`kind` as snake_case string, `signature` optional, `children` recursive) is acceptable.
- [ ] Sanity-check on a TS / Python / Go file in the repo to make sure no language-specific tree-sitter grammars regress (this PR only adds renderers; extraction is unchanged).

### Notes

- Rendering lives in a new `pub(crate) outline_format` module and exposes only three free functions (`markdown`, `structured`, `tabular`). The command itself is in `commands/outline.rs`.
- JSON output uses a local `OutlineEntryDto` mirror of `fff_symbol::OutlineEntry` so we don't have to add `Serialize` to the upstream type.
- No public API changes outside `fff-cli`.
