### PR TITLE
feat(scry): add siblings subcommand to surface peer symbols

### DIFF
--- a/crates/fff-cli/src/cli.rs
+++ b/crates/fff-cli/src/cli.rs
@@ -60,6 +60,9 @@ pub enum Command {
     /// List callees referenced inside a symbol body (NEW).
     Callees(commands::callees::Args),
 
+    /// List sibling symbols (peers in the same parent scope).
+    Siblings(commands::siblings::Args),
+
     /// Auto-classify a free-form query and route it to the right backend.
     Dispatch(commands::dispatch::Args),
 
@@ -86,6 +89,7 @@ impl Cli {
             Command::Symbol(a) => commands::symbol::run(a, &root, self.format),
             Command::Callers(a) => commands::callers::run(a, &root, self.format),
             Command::Callees(a) => commands::callees::run(a, &root, self.format),
+            Command::Siblings(a) => commands::siblings::run(a, &root, self.format),
             Command::Dispatch(a) => commands::dispatch::run(a, &root, self.format),
             Command::Index(a) => commands::index::run(a, &root, self.format),
             Command::Mcp(a) => commands::mcp::run(a, &root),

--- a/crates/fff-cli/src/commands/mod.rs
+++ b/crates/fff-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod outline;
 pub(crate) mod outline_format;
 pub(crate) mod pagination;
 pub mod read;
+pub mod siblings;
 pub mod symbol;
 
 use std::path::Path;

--- a/crates/fff-cli/src/commands/siblings.rs
+++ b/crates/fff-cli/src/commands/siblings.rs
@@ -1,0 +1,273 @@
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use anyhow::Result;
+use clap::Parser;
+use serde::Serialize;
+
+use fff_engine::Engine;
+use fff_symbol::lang::detect_file_type;
+use fff_symbol::types::{FileType, OutlineEntry, OutlineKind};
+
+use crate::cli::OutputFormat;
+use crate::commands::pagination::{footer, Page};
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// Symbol whose siblings (same parent scope) should be listed.
+    pub name: String,
+
+    /// Maximum siblings returned in this page.
+    #[arg(long, default_value_t = 100)]
+    pub limit: usize,
+
+    /// Skip this many siblings before starting the page.
+    #[arg(long, default_value_t = 0)]
+    pub offset: usize,
+
+    /// Include `Import` entries as siblings. Off by default because most
+    /// callers want structural peers (functions/classes/structs), not the
+    /// import block.
+    #[arg(long, default_value_t = false)]
+    pub include_imports: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SiblingHit {
+    name: String,
+    kind: String,
+    path: String,
+    line: u32,
+    end_line: u32,
+    // Path to the parent definition the target lives inside, or "<file>" when
+    // the target is a top-level entry. Useful when the same target name has
+    // multiple definitions in the same file (rare but possible).
+    parent: String,
+    // The definition site the sibling is reported for. A target with N
+    // definitions produces up to N sibling groups, all flattened into the
+    // same Vec but keyed by `target_path` so callers can group them back.
+    target_path: String,
+    target_line: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct SiblingsOutput {
+    name: String,
+    hits: Vec<SiblingHit>,
+    total: usize,
+    offset: usize,
+    has_more: bool,
+}
+
+pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
+    let engine = Engine::default();
+    engine.index(root);
+
+    let definitions = engine.handles.symbols.lookup_exact(&args.name);
+    let mut hits: Vec<SiblingHit> = Vec::new();
+
+    for def in &definitions {
+        let Some(outline) = load_outline(&engine, &def.path) else {
+            continue;
+        };
+        let Some((parent_label, siblings)) = find_siblings(&outline, &args.name, def.line) else {
+            continue;
+        };
+        let target_path = def.path.to_string_lossy().to_string();
+        for s in siblings {
+            if !args.include_imports && s.kind == OutlineKind::Import {
+                continue;
+            }
+            hits.push(SiblingHit {
+                name: s.name.clone(),
+                kind: format!("{:?}", s.kind).to_lowercase(),
+                path: target_path.clone(),
+                line: s.start_line,
+                end_line: s.end_line,
+                parent: parent_label.clone(),
+                target_path: target_path.clone(),
+                target_line: def.line,
+            });
+        }
+    }
+
+    let page = Page::paginate(hits, args.offset, args.limit);
+    let payload = SiblingsOutput {
+        name: args.name,
+        total: page.total,
+        offset: page.offset,
+        has_more: page.has_more,
+        hits: page.items,
+    };
+    super::emit(format, &payload, |p| {
+        let mut out = String::new();
+        for h in &p.hits {
+            out.push_str(&format!(
+                "{} ({}) @ {}:{}  [parent: {}, target: {}:{}]\n",
+                h.name, h.kind, h.path, h.line, h.parent, h.target_path, h.target_line
+            ));
+        }
+        if p.total == 0 {
+            out.push_str("[no siblings found]\n");
+        } else {
+            out.push_str(&footer(p.total, p.offset, p.hits.len(), p.has_more));
+        }
+        out
+    })
+}
+
+fn load_outline(engine: &Engine, path: &PathBuf) -> Option<Vec<OutlineEntry>> {
+    let lang = match detect_file_type(path) {
+        FileType::Code(l) => l,
+        _ => return None,
+    };
+    let content = std::fs::read_to_string(path).ok()?;
+    let mtime = std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    Some(
+        engine
+            .handles
+            .outlines
+            .get_or_compute(path, mtime, &content, lang),
+    )
+}
+
+// Walk the outline looking for an entry whose name == target and whose
+// start_line == target_line. Return its parent's siblings (i.e. peers of the
+// target). For top-level targets, the "parent" is the file itself.
+fn find_siblings(
+    outline: &[OutlineEntry],
+    target: &str,
+    target_line: u32,
+) -> Option<(String, Vec<OutlineEntry>)> {
+    // First, see if the target is a top-level entry.
+    if outline
+        .iter()
+        .any(|e| e.name == target && e.start_line == target_line)
+    {
+        let peers: Vec<OutlineEntry> = outline
+            .iter()
+            .filter(|e| !(e.name == target && e.start_line == target_line))
+            .cloned()
+            .collect();
+        return Some(("<file>".to_string(), peers));
+    }
+    // Otherwise, descend looking for a parent containing the target.
+    for parent in outline {
+        if let Some(found) = find_in_children(parent, target, target_line) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn find_in_children(
+    parent: &OutlineEntry,
+    target: &str,
+    target_line: u32,
+) -> Option<(String, Vec<OutlineEntry>)> {
+    if parent
+        .children
+        .iter()
+        .any(|c| c.name == target && c.start_line == target_line)
+    {
+        let peers: Vec<OutlineEntry> = parent
+            .children
+            .iter()
+            .filter(|c| !(c.name == target && c.start_line == target_line))
+            .cloned()
+            .collect();
+        return Some((parent.name.clone(), peers));
+    }
+    for c in &parent.children {
+        if let Some(found) = find_in_children(c, target, target_line) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{find_siblings, OutlineEntry};
+    use fff_symbol::types::OutlineKind;
+
+    fn entry(kind: OutlineKind, name: &str, start: u32, end: u32) -> OutlineEntry {
+        OutlineEntry {
+            kind,
+            name: name.to_string(),
+            start_line: start,
+            end_line: end,
+            signature: None,
+            children: Vec::new(),
+            doc: None,
+        }
+    }
+
+    #[test]
+    fn top_level_target_returns_other_top_level_entries() {
+        let outline = vec![
+            entry(OutlineKind::Function, "alpha", 1, 5),
+            entry(OutlineKind::Function, "beta", 7, 12),
+            entry(OutlineKind::Struct, "Config", 14, 20),
+        ];
+        let (parent, peers) = find_siblings(&outline, "beta", 7).expect("beta found");
+        assert_eq!(parent, "<file>");
+        let names: Vec<&str> = peers.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "Config"]);
+    }
+
+    #[test]
+    fn nested_target_returns_other_children_under_same_parent() {
+        let mut cls = entry(OutlineKind::Class, "Cls", 1, 50);
+        cls.children.push(entry(OutlineKind::Function, "a", 5, 10));
+        cls.children.push(entry(OutlineKind::Function, "b", 12, 18));
+        cls.children.push(entry(OutlineKind::Function, "c", 20, 25));
+        let other = entry(OutlineKind::Function, "free", 60, 65);
+        let outline = vec![cls, other];
+
+        let (parent, peers) = find_siblings(&outline, "b", 12).expect("b found");
+        assert_eq!(parent, "Cls");
+        let names: Vec<&str> = peers.iter().map(|e| e.name.as_str()).collect();
+        // `free` is NOT a sibling of `b` because they're in different scopes.
+        assert_eq!(names, vec!["a", "c"]);
+    }
+
+    #[test]
+    fn unknown_target_returns_none() {
+        let outline = vec![entry(OutlineKind::Function, "alpha", 1, 5)];
+        assert!(find_siblings(&outline, "nope", 1).is_none());
+    }
+
+    #[test]
+    fn deeply_nested_target_found_via_recursion() {
+        let mut leaf = entry(OutlineKind::Function, "deep", 30, 40);
+        leaf.children
+            .push(entry(OutlineKind::Function, "deeper", 32, 35));
+        let mut mid = entry(OutlineKind::Class, "Mid", 20, 50);
+        mid.children.push(leaf);
+        mid.children
+            .push(entry(OutlineKind::Function, "midpeer", 41, 45));
+        let outline = vec![mid];
+
+        let (parent, peers) = find_siblings(&outline, "deeper", 32).expect("deeper found");
+        assert_eq!(parent, "deep");
+        assert!(peers.is_empty());
+    }
+
+    #[test]
+    fn target_with_same_name_as_peer_at_different_line_is_not_self() {
+        // Pathological: two top-level entries share the name (overload-ish).
+        // The one we asked for (line 7) is the "self"; the other (line 20)
+        // remains as a sibling.
+        let outline = vec![
+            entry(OutlineKind::Function, "f", 7, 10),
+            entry(OutlineKind::Function, "f", 20, 25),
+        ];
+        let (parent, peers) = find_siblings(&outline, "f", 7).expect("f@7 found");
+        assert_eq!(parent, "<file>");
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].start_line, 20);
+    }
+}


### PR DESCRIPTION
## Summary

New `scry siblings <name>` subcommand surfaces peer symbols defined at the same scope as the target — within the same parent (class / module / file).

**Behaviour**

For each definition site of `<name>`:
1. Load the file's outline through the engine's `OutlineCache` (mtime-keyed; cheap on a hot index).
2. Locate the focal entry by `(name, start_line)`.
3. Emit its parent's other children. Top-level targets get all other top-level entries. Nested targets (e.g. methods inside a class) get peer methods of the same enclosing class — `free` functions are *not* siblings of methods.

**Flags**

- `--limit` / `--offset` — pagination, same shape as `symbol` / `callers` / `callees`.
- `--include-imports` — off by default. Outline extraction emits one `Import` entry per use-statement which would drown out the signal; flip on if you really want them.

**Output**

JSON shape:
```json
{
  "name": "run",
  "total": 42,
  "offset": 0,
  "has_more": true,
  "hits": [
    {
      "name": "Args", "kind": "struct",
      "path": "...", "line": 10, "end_line": 21,
      "parent": "<file>",
      "target_path": "...", "target_line": 37
    },
    ...
  ]
}
```

`parent` is `"<file>"` for top-level targets, otherwise the enclosing definition's name. `target_path` / `target_line` identify which definition site this sibling group belongs to (relevant when a name has multiple definitions in the same file).

Text output mirrors the JSON one line per hit, plus the standard `[start-end of total]` pagination footer.

**Smoke test**

```
$ scry siblings run --limit 3
Args (struct)    @ ./crates/fff-cli/src/commands/grep.rs:10  [parent: <file>, target: ...:37]
GrepHit (struct) @ ./crates/fff-cli/src/commands/grep.rs:24  [parent: <file>, target: ...:37]
GrepResult (struct) @ ./crates/fff-cli/src/commands/grep.rs:31 [parent: <file>, target: ...:37]
[1-3 of 42] — next: --offset 3
```

`cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`, and `cargo test -p fff-cli` (34 tests, 5 new) all clean.

## Review & Testing Checklist for Human

- [ ] Confirm the default of `--include-imports=false` is the right call. Easy to flip if you want imports on by default.
- [ ] Confirm the `parent: "<file>"` sentinel for top-level targets is acceptable, vs. e.g. just omitting it.
- [ ] Sanity-check on a multi-method class (TS / Python) to verify nested resolution behaves: `scry siblings <method-name>` should list peer methods of the same class only.

### Notes

- Sibling resolution is purely outline-driven — no AST queries beyond what `get_outline_entries` already produces, no extra tree-sitter passes per call.
- 5 unit tests on `find_siblings` cover: top-level lookup, nested lookup with the right parent scope, unknown target → `None`, deep recursion, and the pathological case of two top-level entries sharing a name (we identify the focal one by `(name, start_line)`, not name alone).
- No public API changes outside `fff-cli`.
