### PR TITLE
feat(scry): add 'scry guide' subcommand with embedded agent guide

### DIFF
--- a/crates/fff-cli/assets/AGENT_GUIDE.md
+++ b/crates/fff-cli/assets/AGENT_GUIDE.md
@@ -1,0 +1,132 @@
+# scry — agent guide
+
+`scry` is a unified code search, read, and symbol-lookup tool. Output is
+token-budget aware and uniformly available as either human text or JSON
+(`--format json`), so agents can stay on a single CLI for the whole
+read-and-reason loop.
+
+This guide describes the public sub-commands as of the version that
+shipped this file. Versions are stable; new behaviour is added as new
+flags rather than via behaviour changes to existing flags.
+
+## Global flags
+
+* `--root <DIR>` — project root to search/index. Defaults to the
+  current working directory.
+* `--format text|json` — output format. `text` is the default and is
+  intended for humans; `json` is canonical and intended for tools.
+
+All sub-commands accept these.
+
+## Pagination
+
+Listing sub-commands (`find`, `symbol`, `callers`, `callees`,
+`siblings`) take:
+
+* `--limit <N>` — max items in this page (defaults differ per command;
+  typically 50–100).
+* `--offset <N>` — skip this many items before the page starts.
+  Defaults to 0.
+
+JSON responses always include `total`, `offset`, `has_more`. Text
+responses end with a footer like `[1-50 of 217] — next: --offset 50`
+that tells the next page's `--offset` directly.
+
+## Sub-commands
+
+### `find <needle>`
+Filename matcher. Substring (case-insensitive) match against full
+file paths under `--root`. Useful as the first step when you know a
+filename fragment but not the full path.
+
+### `glob <pattern>`
+Shell-style glob over file paths (`**`, `*`, `?`, character classes).
+
+### `grep <regex>`
+Content search across the project. Powered by `ripgrep` semantics for
+gitignore handling.
+
+### `read <target>`
+Read a file, optionally with a `path:line` suffix to highlight a
+span. Output is truncated to a token budget.
+
+* `--budget <N>` — total token budget (default 25000). Effective byte
+  cap ≈ `tokens × 0.85 × 4`; the remaining ≈15% is reserved for the
+  envelope and truncation footer.
+* `--filter none|minimal|aggressive` — `none` keeps the file as-is;
+  `minimal` strips full-line comments; `aggressive` collapses
+  impl/class bodies to fit more files into the same budget.
+
+### `outline <path>`
+Tree-sitter outline of a single file: top-level functions, classes,
+structs, imports, and their immediate children where applicable.
+
+* `--style tabular|markdown|structured` — text rendering. `tabular`
+  (default) is fixed-width columns; `markdown` is nested bullets with
+  backticked names and signatures; `structured` is an ASCII tree
+  (`├─` / `└─`).
+* JSON output (`--format json`) is independent of `--style` and emits
+  the entry tree directly with `kind`, `name`, `start_line`,
+  `end_line`, `signature`, `children`.
+
+### `symbol <name>`
+Look up a symbol definition by name. Tree-sitter AST-driven, not
+substring. Trailing `*` is treated as a prefix glob: `symbol Foo*`
+matches every name starting with `Foo`.
+
+JSON response includes a `facets` field: `{ total, by_kind }` counted
+on the *full* candidate set (i.e. unaffected by `--offset` /
+`--limit`). Text output appends a `by kind: function: 12, struct: 3`
+line under the pagination footer.
+
+### `callers <name>`
+Find lines that reference `<name>` outside its own definition site.
+Bloom-narrowed first, then confirmed with a literal-text pass.
+
+### `callees <name>`
+Identifiers referenced inside the body of `<name>`, then resolved
+back to definitions via the symbol index. Hits with the same
+`(name, path, line)` triple are de-duplicated even when they came
+from multiple definition bodies of `<name>`.
+
+### `siblings <name>`
+Other symbols defined at the same scope as `<name>` — peer methods of
+the same class, peer functions in the same file, peer items in the
+same module. Top-level targets get all other top-level entries.
+
+* `--include-imports` — off by default; on returns the file's import
+  block as siblings as well.
+
+Each hit carries `parent` (`"<file>"` for top-level, otherwise the
+enclosing definition's name) and `target_path`/`target_line` so
+multiple definition sites of the same name remain disambiguated.
+
+### `dispatch <query>`
+Free-form classifier that routes a query to the right backend
+(`symbol`, `symbol_glob`, `file_path`, `glob`, or content fallback).
+
+### `index`
+Build / refresh the on-disk indexes (Bigram, Bloom, Symbol, Outline)
+without running a query. Useful for warming up before a session.
+
+### `mcp`
+Run as an MCP (Model Context Protocol) server over stdio. Replaces
+agent built-ins like Grep / Glob / Read while still exposing the same
+sub-commands above.
+
+### `guide`
+Print this document.
+
+## Conventions and tips
+
+* All listing commands return `total` so an agent can decide whether
+  to widen, paginate, or refine the query without a second round-trip.
+* `siblings` + `outline` together let an agent reconstruct the
+  enclosing scope of any symbol without re-reading the file: outline
+  for kind/signature, siblings for "what else is nearby".
+* Prefer `--format json` for any programmatic consumer; text output
+  may evolve for readability while JSON is treated as part of the
+  contract.
+* Use `--limit` aggressively. Most lookups want the top 5–20 hits;
+  the cost of the underlying scan is independent of `--limit` but
+  output marshalling is not.

--- a/crates/fff-cli/src/cli.rs
+++ b/crates/fff-cli/src/cli.rs
@@ -68,6 +68,9 @@ pub enum Command {
 
     /// Run as MCP server over stdio (replaces agent built-ins Grep/Glob/Read).
     Mcp(commands::mcp::Args),
+
+    /// Print the embedded agent guide.
+    Guide(commands::guide::Args),
 }
 
 impl Cli {
@@ -89,6 +92,7 @@ impl Cli {
             Command::Dispatch(a) => commands::dispatch::run(a, &root, self.format),
             Command::Index(a) => commands::index::run(a, &root, self.format),
             Command::Mcp(a) => commands::mcp::run(a, &root),
+            Command::Guide(a) => commands::guide::run(a, &root, self.format),
         }
     }
 }

--- a/crates/fff-cli/src/commands/guide.rs
+++ b/crates/fff-cli/src/commands/guide.rs
@@ -1,0 +1,24 @@
+use std::path::Path;
+
+use anyhow::Result;
+use clap::Parser;
+use serde::Serialize;
+
+use crate::cli::OutputFormat;
+
+const GUIDE_TEXT: &str = include_str!("../../assets/AGENT_GUIDE.md");
+
+#[derive(Debug, Parser)]
+pub struct Args {}
+
+#[derive(Debug, Serialize)]
+struct GuideOutput {
+    body: String,
+}
+
+pub fn run(_args: Args, _root: &Path, format: OutputFormat) -> Result<()> {
+    let payload = GuideOutput {
+        body: GUIDE_TEXT.to_string(),
+    };
+    super::emit(format, &payload, |p| p.body.clone())
+}

--- a/crates/fff-cli/src/commands/mod.rs
+++ b/crates/fff-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod facets;
 pub mod find;
 pub mod glob;
 pub mod grep;
+pub mod guide;
 pub mod index;
 pub mod mcp;
 pub mod outline;

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,16 @@
         commonArgs = {
           pname = cargoToml.package.name;
           version = cargoToml.package.version;
-          src = craneLib.cleanCargoSource ./.;
+          # cleanCargoSource strips non-rust files; we need to keep the
+          # AGENT_GUIDE.md asset that fff-cli pulls in via include_str!.
+          src = pkgs.lib.cleanSourceWith {
+            src = ./.;
+            filter =
+              path: type:
+              (pkgs.lib.hasInfix "/crates/fff-cli/assets/" path)
+              || (craneLib.filterCargoSources path type);
+            name = "source";
+          };
           strictDeps = true;
 
           nativeBuildInputs = [ pkgs.pkg-config pkgs.perl zig pkgs.llvmPackages.libclang.lib ];


### PR DESCRIPTION
## Summary

Adds `scry guide` — a sub-command that prints an embedded markdown agent guide.

**Why**

Agents using `scry` (either through the CLI directly or via the MCP server) need a single, deterministic source of truth for what sub-commands exist, what their flags mean, and what shape the JSON output takes. Without it, prompts have to either embed `--help` snippets per command or guess.

**What it does**

- `scry guide` prints the markdown to stdout.
- `scry --format json guide` returns `{ "body": "<markdown>" }` so agents can lift it into a system message without re-parsing markdown.

**How it ships**

The guide content lives at `crates/fff-cli/assets/AGENT_GUIDE.md` (so it's editable as a normal markdown file with normal review tooling) and is baked into the binary via `include_str!` — no install-time file shipping required.

**What's documented**

- Global flags (`--root`, `--format`).
- Pagination contract (`--limit`, `--offset`, `total` / `offset` / `has_more` JSON fields, the `[1-50 of 217] — next: --offset 50` text footer).
- All public sub-commands: `find`, `glob`, `grep`, `read` (budget + filter levels), `outline` (markdown / structured / tabular), `symbol` (with facets), `callers`, `callees` (with dedup semantics), `dispatch`, `index`, `mcp`, and `guide`.
- Conventions and tips (JSON is canonical; text may evolve).

This describes scry as it is **on `main` today**. Future PRs that change behaviour or add sub-commands should also update this guide in the same change.

**Note re: PR #4**

PR #4 (siblings sub-command, currently open) is independent of this branch — when both merge, the guide will need a small follow-up to add a `### siblings` section. Happy to do that as a one-line follow-up after #4 lands.

## Smoke

```
$ scry guide | head -3
# scry — agent guide

`scry` is a unified code search, read, and symbol-lookup tool. ...

$ scry --format json guide | jq -r '.body | length'
5173
```

`cargo build`, `cargo clippy -p fff-cli -- -D warnings`, `cargo fmt --check`, `cargo test -p fff-cli` (29 tests, no new ones — guide is essentially a constant) all clean.

## Review & Testing Checklist for Human

- [ ] Read through `crates/fff-cli/assets/AGENT_GUIDE.md` and confirm it accurately describes the current behaviour. If anything's wrong, the markdown file is editable in-tree.
- [ ] Confirm the `{ body: <markdown> }` JSON shape is acceptable; alternatives include emitting the raw markdown without an envelope.
