### PR TITLE
feat(scry): add --section / --full to read for structural reads

### DIFF
--- a/crates/fff-cli/src/commands/read.rs
+++ b/crates/fff-cli/src/commands/read.rs
@@ -1,17 +1,23 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::Parser;
 use serde::Serialize;
 
-use fff_budget::FilterLevel;
+use fff_budget::{
+    apply_preserving_footer, smart_truncate, AggressiveFilter, BudgetSplit, FilterLevel,
+    FilterStrategy, MinimalFilter, NoFilter, TruncationOutcome,
+};
 use fff_engine::{Engine, EngineConfig};
+use fff_symbol::lang::detect_file_type;
+use fff_symbol::types::{FileType, OutlineEntry};
 
 use crate::cli::OutputFormat;
 
 #[derive(Debug, Parser)]
 pub struct Args {
-    /// File path to read; may be of the form `path:line` to highlight a span.
+    /// File path to read; may be of the form `path:line` to focus a span.
     pub target: String,
 
     /// Token budget for the output (default 25000).
@@ -24,46 +30,293 @@ pub struct Args {
     /// strips full-line comments, `aggressive` collapses impl/class bodies.
     #[arg(long, default_value = "minimal")]
     pub filter: String,
+
+    /// Return only the structural section (function/class/struct) that
+    /// contains the line in `path:line`. Mutually exclusive with `--full`.
+    #[arg(long, default_value_t = false, conflicts_with = "full")]
+    pub section: bool,
+
+    /// Force whole-file mode even if `path:line` was given. Default if no
+    /// flag is set, but lets you pin behaviour explicitly.
+    #[arg(long, default_value_t = false)]
+    pub full: bool,
 }
 
 #[derive(Debug, Serialize)]
 struct ReadOutput {
     path: String,
+    mode: &'static str,
     body: String,
     kept_bytes: usize,
     footer_bytes: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    line: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    section: Option<SectionMeta>,
+}
+
+#[derive(Debug, Serialize)]
+struct SectionMeta {
+    kind: String,
+    name: String,
+    start_line: u32,
+    end_line: u32,
 }
 
 pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
-    let level = match args.filter.as_str() {
+    let level = filter_level(&args.filter);
+    let budget = args.budget.unwrap_or(25_000);
+
+    let (path_part, line) = parse_target(&args.target);
+    let path = if Path::new(path_part).is_absolute() {
+        PathBuf::from(path_part)
+    } else {
+        root.join(path_part)
+    };
+
+    if args.section {
+        let line =
+            line.ok_or_else(|| anyhow!("--section requires the target to be in `path:line` form"))?;
+        let payload = read_section(&path, line, level, budget)?;
+        return super::emit(format, &payload, section_text);
+    }
+
+    // --full or default: whole-file read via the engine.
+    let cfg = EngineConfig {
+        filter_level: level,
+        total_token_budget: budget,
+        ..EngineConfig::default()
+    };
+    let engine = Engine::new(cfg);
+    let res = engine.read(&path);
+
+    let payload = ReadOutput {
+        path: res.path.to_string_lossy().to_string(),
+        mode: "full",
+        body: res.body.clone(),
+        kept_bytes: res.outcome.kept_bytes,
+        footer_bytes: res.outcome.footer_bytes,
+        line,
+        section: None,
+    };
+    super::emit(format, &payload, |p| {
+        let mut out = String::new();
+        if let Some(l) = p.line {
+            out.push_str(&format!("// {}:{}\n", p.path, l));
+        }
+        out.push_str(&p.body);
+        out
+    })
+}
+
+fn filter_level(s: &str) -> FilterLevel {
+    match s {
         "none" => FilterLevel::None,
         "aggressive" => FilterLevel::Aggressive,
         _ => FilterLevel::Minimal,
+    }
+}
+
+fn parse_target(target: &str) -> (&str, Option<u32>) {
+    if let Some((p, rest)) = target.rsplit_once(':') {
+        if let Ok(n) = rest.parse::<u32>() {
+            if n > 0 {
+                return (p, Some(n));
+            }
+        }
+    }
+    (target, None)
+}
+
+fn read_section(path: &Path, line: u32, level: FilterLevel, budget: u64) -> Result<ReadOutput> {
+    let lang = match detect_file_type(path) {
+        FileType::Code(l) => l,
+        _ => return Err(anyhow!("not a code file: {}", path.display())),
     };
 
+    let max_bytes_default = EngineConfig::default().max_bytes_per_result;
     let cfg = EngineConfig {
         filter_level: level,
-        total_token_budget: args.budget.unwrap_or(25_000),
+        total_token_budget: budget,
         ..EngineConfig::default()
     };
     let engine = Engine::new(cfg);
 
-    let path_part = args
-        .target
-        .rsplit_once(':')
-        .map_or(args.target.as_str(), |(p, _)| p);
-    let p = if Path::new(path_part).is_absolute() {
-        std::path::PathBuf::from(path_part)
-    } else {
-        root.join(path_part)
-    };
-    let res = engine.read(&p);
+    let content =
+        std::fs::read_to_string(path).map_err(|e| anyhow!("read {}: {e}", path.display()))?;
+    let mtime = std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    let outline = engine
+        .handles
+        .outlines
+        .get_or_compute(path, mtime, &content, lang);
 
-    let payload = ReadOutput {
-        path: res.path.to_string_lossy().to_string(),
-        body: res.body.clone(),
-        kept_bytes: res.outcome.kept_bytes,
-        footer_bytes: res.outcome.footer_bytes,
+    let entry = deepest_containing(&outline, line)
+        .ok_or_else(|| anyhow!("no structural section contains line {line}"))?;
+
+    let slice = slice_lines(&content, entry.start_line, entry.end_line);
+
+    let filter: Box<dyn FilterStrategy> = match level {
+        FilterLevel::None => Box::new(NoFilter),
+        FilterLevel::Minimal => Box::new(MinimalFilter),
+        FilterLevel::Aggressive => Box::new(AggressiveFilter),
     };
-    super::emit(format, &payload, |p| p.body.clone())
+    let filtered = filter.apply(&slice);
+
+    let split = BudgetSplit::default_for(budget);
+    let body_budget_bytes = (split.body * 4) as usize;
+    let max_bytes = body_budget_bytes.min(max_bytes_default);
+
+    let (body, outcome) = budgeted(&filtered, max_bytes);
+
+    Ok(ReadOutput {
+        path: path.to_string_lossy().to_string(),
+        mode: "section",
+        body,
+        kept_bytes: outcome.kept_bytes,
+        footer_bytes: outcome.footer_bytes,
+        line: Some(line),
+        section: Some(SectionMeta {
+            kind: format!("{:?}", entry.kind).to_lowercase(),
+            name: entry.name.clone(),
+            start_line: entry.start_line,
+            end_line: entry.end_line,
+        }),
+    })
+}
+
+fn deepest_containing(entries: &[OutlineEntry], line: u32) -> Option<OutlineEntry> {
+    let mut best: Option<OutlineEntry> = None;
+    for e in entries {
+        if e.start_line <= line && line <= e.end_line {
+            // Prefer a deeper child if one also contains the line.
+            if let Some(child) = deepest_containing(&e.children, line) {
+                best = Some(child);
+            } else {
+                best = Some(e.clone());
+            }
+        }
+    }
+    best
+}
+
+fn slice_lines(content: &str, start_line: u32, end_line: u32) -> String {
+    let start = start_line.saturating_sub(1) as usize;
+    let end = end_line as usize;
+    let mut out = String::new();
+    for (i, line) in content.lines().enumerate() {
+        if i >= start && i < end {
+            out.push_str(line);
+            out.push('\n');
+        }
+        if i >= end {
+            break;
+        }
+    }
+    out
+}
+
+fn budgeted(filtered: &str, max_bytes: usize) -> (String, TruncationOutcome) {
+    let mut buf = String::new();
+    let footer = "[truncated to budget]\n";
+    let outcome = if filtered.len() <= max_bytes {
+        let (out, oc) = smart_truncate(filtered, max_bytes);
+        buf.push_str(&out);
+        oc
+    } else {
+        apply_preserving_footer(&mut buf, max_bytes, footer, |target, budget| {
+            let take = filtered.len().min(budget);
+            target.push_str(&filtered[..take]);
+            take
+        })
+    };
+    (buf, outcome)
+}
+
+fn section_text(p: &ReadOutput) -> String {
+    let mut out = String::new();
+    if let Some(s) = &p.section {
+        out.push_str(&format!(
+            "// {} {} (lines {}-{})\n",
+            s.kind, s.name, s.start_line, s.end_line
+        ));
+    } else if let Some(l) = p.line {
+        out.push_str(&format!("// {}:{}\n", p.path, l));
+    }
+    out.push_str(&p.body);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fff_symbol::types::OutlineKind;
+
+    fn entry(
+        kind: OutlineKind,
+        name: &str,
+        start: u32,
+        end: u32,
+        children: Vec<OutlineEntry>,
+    ) -> OutlineEntry {
+        OutlineEntry {
+            kind,
+            name: name.to_string(),
+            start_line: start,
+            end_line: end,
+            signature: None,
+            children,
+            doc: None,
+        }
+    }
+
+    #[test]
+    fn parses_path_and_line_when_present() {
+        assert_eq!(parse_target("foo.rs:42"), ("foo.rs", Some(42)));
+        assert_eq!(parse_target("a/b/foo.rs:1"), ("a/b/foo.rs", Some(1)));
+    }
+
+    #[test]
+    fn parses_path_only_when_no_colon_or_non_numeric_suffix() {
+        assert_eq!(parse_target("foo.rs"), ("foo.rs", None));
+        assert_eq!(parse_target("foo.rs:bar"), ("foo.rs:bar", None));
+        assert_eq!(parse_target("foo.rs:0"), ("foo.rs:0", None));
+    }
+
+    #[test]
+    fn deepest_containing_returns_innermost_match() {
+        let outline = vec![entry(
+            OutlineKind::Class,
+            "Cls",
+            1,
+            50,
+            vec![entry(OutlineKind::Function, "method", 10, 30, vec![])],
+        )];
+        let inner = deepest_containing(&outline, 20).expect("found");
+        assert_eq!(inner.name, "method");
+        let outer = deepest_containing(&outline, 5).expect("found");
+        assert_eq!(outer.name, "Cls");
+    }
+
+    #[test]
+    fn deepest_containing_returns_none_when_no_match() {
+        let outline = vec![entry(OutlineKind::Function, "f", 10, 20, vec![])];
+        assert!(deepest_containing(&outline, 5).is_none());
+        assert!(deepest_containing(&outline, 25).is_none());
+    }
+
+    #[test]
+    fn slice_lines_is_inclusive_of_both_ends() {
+        let content = "L1\nL2\nL3\nL4\nL5\n";
+        assert_eq!(slice_lines(content, 2, 4), "L2\nL3\nL4\n");
+        assert_eq!(slice_lines(content, 1, 1), "L1\n");
+        assert_eq!(slice_lines(content, 5, 5), "L5\n");
+    }
+
+    #[test]
+    fn slice_lines_clamps_when_end_exceeds_file() {
+        let content = "L1\nL2\n";
+        assert_eq!(slice_lines(content, 1, 99), "L1\nL2\n");
+    }
 }


### PR DESCRIPTION
## Summary

Adds `--section` and `--full` to `scry read`, plus first-class support for `path:line` targets. The structural read lets agents fetch just the function / class / struct that contains a given line instead of asking for the whole file.

**Behaviour matrix**

| Invocation | Body returned |
|---|---|
| `scry read foo.rs` | whole file, filtered+budgeted (unchanged) |
| `scry read foo.rs:42` | whole file; `line` is recorded so callers can highlight |
| `scry read foo.rs:42 --section` | only the deepest outline entry containing line 42 |
| `scry read foo.rs --full` | explicit "whole file"; same as the bare form, but pinned |
| `scry read foo.rs:42 --section --full` | rejected by clap (mutually exclusive) |

**How `--section` resolves**

For `path:line`:

1. Detect language via `fff-symbol::lang::detect_file_type`.
2. Pull the outline through the engine's `OutlineCache` (mtime-keyed, hot in normal sessions).
3. Walk the outline tree picking the deepest entry whose `[start_line, end_line]` window contains `line` — so a method inside a class wins over the class.
4. Slice the file at `start_line..=end_line`, run it through the same filter (`none` / `minimal` / `aggressive`) and budget pipeline as a whole-file read.

**Output shape**

JSON now includes:
- `mode`: `"full"` or `"section"`
- `line` (optional): the requested line number
- `section` (optional): `{ kind, name, start_line, end_line }` when `--section` resolved

Text output gets a leading marker:
- `// <path>:<line>` for full reads with a line
- `// <kind> <name> (lines <a>-<b>)` for sections

**Smoke**

```
$ scry read crates/fff-cli/src/commands/read.rs:80 --section
// function run (lines 66-110)
pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
    let level = filter_level(&args.filter);
    let budget = args.budget.unwrap_or(25_000);
    ...
}

$ scry --format json read .../read.rs:80 --section | jq '{mode, line, section, kept_bytes}'
{
  "mode": "section",
  "line": 80,
  "section": { "kind": "function", "name": "run", "start_line": 66, "end_line": 110 },
  "kept_bytes": 1350
}

$ scry read .../read.rs:80 --section --full
error: the argument '--section' cannot be used with '--full'
```

`cargo build`, `cargo clippy -p fff-cli -- -D warnings`, `cargo fmt --check`, `cargo test -p fff-cli` (35 tests, 5 new) all clean.

## Review & Testing Checklist for Human

- [ ] Confirm the "deepest match wins" rule is what you want for nested entries (e.g. method-in-class). The alternative is "outermost wins"; trivial to flip if that's preferred.
- [ ] Confirm the text marker formats. `// kind name (lines a-b)` is comment-aligned (works in most languages), but if you'd rather a structured prefix line, easy to change.
- [ ] Sanity check on a TS / Python file: `scry read app.py:<line-inside-method> --section` should slice to the method, not the class.

### Notes

- No public API changes outside `fff-cli`. `Engine::read` stays whole-file; the section path is implemented in the CLI command since it composes `OutlineCache.get_or_compute` with the existing budget primitives.
- `parse_target` rejects non-numeric and zero-line suffixes (so `path:foo.json:1` keeps `foo.json:1` as the "path:line" pair only when the suffix actually parses as a positive `u32`).
- `--section` errors clearly when no outline entry contains the requested line (e.g. between two top-level definitions): `Error: no structural section contains line N`.
