### PR TITLE
feat(scry): tree-sitter callee resolution for 'callees' command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/crates/fff-cli/Cargo.toml
+++ b/crates/fff-cli/Cargo.toml
@@ -14,6 +14,7 @@ fff-search = { path = "../fff-core" }
 fff-engine = { workspace = true }
 fff-symbol = { workspace = true }
 fff-budget = { workspace = true }
+tree-sitter = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 ignore = { workspace = true }

--- a/crates/fff-cli/src/commands/callees.rs
+++ b/crates/fff-cli/src/commands/callees.rs
@@ -8,9 +8,11 @@ use clap::Parser;
 use serde::Serialize;
 
 use fff_engine::Engine;
-use fff_symbol::bloom::extract_identifiers;
+use fff_symbol::lang::detect_file_type;
+use fff_symbol::types::FileType;
 
 use crate::cli::OutputFormat;
+use crate::commands::callees_resolve::collect_callees;
 use crate::commands::dedup::dedup_by;
 use crate::commands::pagination::{footer, Page};
 
@@ -52,28 +54,23 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
     let mut hits: Vec<CalleeHit> = Vec::new();
 
     for def in &definitions {
+        let lang = match detect_file_type(&def.path) {
+            FileType::Code(l) => l,
+            _ => continue,
+        };
         let Ok(content) = std::fs::read_to_string(&def.path) else {
             continue;
         };
-        let lines: Vec<&str> = content.lines().collect();
-        let start = (def.line.saturating_sub(1)) as usize;
-        let end = (def.end_line as usize).min(lines.len());
-        if start >= end {
+        let Some(names) = collect_callees(&content, lang, def.line, def.end_line) else {
             continue;
-        }
-        let body = lines[start..end].join("\n");
-
-        let mut seen = std::collections::HashSet::new();
-        for ident in extract_identifiers(&body) {
-            if !seen.insert(ident.to_string()) {
-                continue;
-            }
+        };
+        for ident in names {
             if ident == args.name {
                 continue;
             }
-            for loc in engine.handles.symbols.lookup_exact(ident) {
+            for loc in engine.handles.symbols.lookup_exact(&ident) {
                 hits.push(CalleeHit {
-                    name: ident.to_string(),
+                    name: ident.clone(),
                     path: loc.path.to_string_lossy().to_string(),
                     line: loc.line,
                 });

--- a/crates/fff-cli/src/commands/callees_resolve.rs
+++ b/crates/fff-cli/src/commands/callees_resolve.rs
@@ -1,0 +1,220 @@
+use std::collections::BTreeSet;
+
+use tree_sitter::{Node, Parser};
+
+use fff_symbol::outline_language;
+use fff_symbol::types::Lang;
+
+// Returns the set of identifier names referenced as call-targets inside lines
+// `[start_line, end_line]` of `content` parsed under `lang`.
+//
+// "Call target" covers the AST nodes most languages use for a call expression,
+// e.g. `call_expression`, `call`, `method_invocation`, `invocation_expression`,
+// `member_call_expression`, plus `macro_invocation` for Rust. The callee
+// identifier is taken from the conventional field (`function`, `name`,
+// `callee`) and reduced to its rightmost name segment, so `mod::Foo::bar()`
+// and `obj.bar()` both yield `bar` — the form the symbol index keys on.
+pub fn collect_callees(
+    content: &str,
+    lang: Lang,
+    start_line: u32,
+    end_line: u32,
+) -> Option<BTreeSet<String>> {
+    let language = outline_language(lang)?;
+    let mut parser = Parser::new();
+    parser.set_language(&language).ok()?;
+    let tree = parser.parse(content, None)?;
+    let source = content.as_bytes();
+
+    let mut out: BTreeSet<String> = BTreeSet::new();
+    walk(tree.root_node(), source, start_line, end_line, &mut out);
+    Some(out)
+}
+
+fn walk(node: Node, src: &[u8], start: u32, end: u32, out: &mut BTreeSet<String>) {
+    let row = node.start_position().row as u32 + 1;
+    if row > end {
+        return;
+    }
+
+    if node_is_call(node) && row >= start {
+        if let Some(name) = extract_callee_name(node, src) {
+            out.insert(name);
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk(child, src, start, end, out);
+    }
+}
+
+fn node_is_call(node: Node) -> bool {
+    matches!(
+        node.kind(),
+        "call_expression"
+            | "call"
+            | "method_invocation"
+            | "method_call"
+            | "function_call_expression"
+            | "member_call_expression"
+            | "invocation_expression"
+            | "new_expression"
+            | "object_creation_expression"
+            | "macro_invocation"
+            | "scoped_call"
+            | "function_call"
+    )
+}
+
+fn extract_callee_name(call: Node, src: &[u8]) -> Option<String> {
+    if call.kind() == "macro_invocation" {
+        if let Some(target) = call
+            .child_by_field_name("macro")
+            .or_else(|| call.child_by_field_name("name"))
+        {
+            return rightmost_name(target, src);
+        }
+    }
+    for field in ["function", "name", "callee", "method"] {
+        if let Some(target) = call.child_by_field_name(field) {
+            return rightmost_name(target, src);
+        }
+    }
+    // Fallback: first named child.
+    call.named_child(0).and_then(|c| rightmost_name(c, src))
+}
+
+fn rightmost_name(node: Node, src: &[u8]) -> Option<String> {
+    match node.kind() {
+        "identifier"
+        | "type_identifier"
+        | "field_identifier"
+        | "property_identifier"
+        | "shorthand_property_identifier"
+        | "shorthand_property_identifier_pattern"
+        | "constant"
+        | "name"
+        | "simple_identifier" => text_of(node, src),
+        "member_expression"
+        | "member_access_expression"
+        | "field_expression"
+        | "field_access"
+        | "scoped_identifier"
+        | "scoped_type_identifier"
+        | "selector_expression"
+        | "qualified_name"
+        | "path"
+        | "scoped_call_expression"
+        | "subscript_expression" => {
+            for field in ["name", "property", "field", "selector"] {
+                if let Some(child) = node.child_by_field_name(field) {
+                    return rightmost_name(child, src);
+                }
+            }
+            (0..node.named_child_count())
+                .rev()
+                .find_map(|i| node.named_child(i))
+                .and_then(|c| rightmost_name(c, src))
+        }
+        _ => {
+            if node.named_child_count() > 0 {
+                node.named_child(node.named_child_count() - 1)
+                    .and_then(|c| rightmost_name(c, src))
+            } else {
+                text_of(node, src)
+            }
+        }
+    }
+}
+
+fn text_of(node: Node, src: &[u8]) -> Option<String> {
+    node.utf8_text(src).ok().map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_collects_simple_call() {
+        let src = r#"
+fn outer() {
+    foo();
+    bar(1, 2);
+}
+"#;
+        let names = collect_callees(src, Lang::Rust, 2, 5).expect("parsed");
+        assert!(names.contains("foo"));
+        assert!(names.contains("bar"));
+    }
+
+    #[test]
+    fn rust_collects_method_and_path() {
+        let src = r#"
+fn outer() {
+    obj.do_thing();
+    crate::module::helper();
+}
+"#;
+        let names = collect_callees(src, Lang::Rust, 2, 5).expect("parsed");
+        assert!(names.contains("do_thing"), "got: {names:?}");
+        assert!(names.contains("helper"), "got: {names:?}");
+    }
+
+    #[test]
+    fn rust_macros_are_collected() {
+        let src = r#"
+fn outer() {
+    println!("hi");
+    vec![1, 2];
+}
+"#;
+        let names = collect_callees(src, Lang::Rust, 2, 5).expect("parsed");
+        assert!(names.contains("println"), "got: {names:?}");
+        assert!(names.contains("vec"), "got: {names:?}");
+    }
+
+    #[test]
+    fn line_window_excludes_calls_outside_range() {
+        let src = r#"
+fn outer() {
+    inside_a();
+}
+
+fn other() {
+    outside_b();
+}
+"#;
+        let names = collect_callees(src, Lang::Rust, 2, 4).expect("parsed");
+        assert!(names.contains("inside_a"));
+        assert!(!names.contains("outside_b"));
+    }
+
+    #[test]
+    fn python_method_invocation_resolves_to_rightmost() {
+        let src = r#"
+def outer():
+    obj.do_thing()
+    pkg.mod.helper(1)
+"#;
+        let names = collect_callees(src, Lang::Python, 2, 4).expect("parsed");
+        assert!(names.contains("do_thing"), "got: {names:?}");
+        assert!(names.contains("helper"), "got: {names:?}");
+    }
+
+    #[test]
+    fn typescript_call_and_new_collected() {
+        let src = r#"
+function outer() {
+    foo();
+    new Bar();
+    obj.qux();
+}
+"#;
+        let names = collect_callees(src, Lang::TypeScript, 2, 6).expect("parsed");
+        assert!(names.contains("foo"), "got: {names:?}");
+        assert!(names.contains("Bar"), "got: {names:?}");
+        assert!(names.contains("qux"), "got: {names:?}");
+    }
+}

--- a/crates/fff-cli/src/commands/mod.rs
+++ b/crates/fff-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod callees;
+pub(crate) mod callees_resolve;
 pub mod callers;
 pub(crate) mod dedup;
 pub mod dispatch;


### PR DESCRIPTION
## Summary

Replaces the substring-style identifier walk in `scry callees` with a real tree-sitter pass over the definition's body. The output shape (paginated `CalleesOutput`) and CLI surface are unchanged — the difference is precision.

## Why

Today `callees` builds a body window with `lines[def.line-1..def.end_line]`, runs `fff_symbol::bloom::extract_identifiers` over that text, and looks each identifier up in the symbol index. That walker is fast and good enough for bloom-filter pre-checks, but as a callee resolver it leaks:

- identifiers that appear in **comments** and **strings**,
- identifiers in **type annotations / generics** that aren't being called,
- **field accesses** like `a.b.c.method()` get reported as four separate "calls" to `a`, `b`, `c`, *and* `method`,
- it **misses macros** (`println!`, `vec!`) because the `!` breaks the word boundary.

Net: a lot of false positives, plus a real false negative for the macro-heavy parts of the codebase.

## What changed

New `commands::callees_resolve` module that:

1. Parses the file under the right grammar via `fff_symbol::outline_language(lang)`.
2. Walks the AST collecting call-like nodes whose start row falls in `[def.line, def.end_line]`. Recognised kinds:
   - `call_expression`, `call`, `function_call`, `function_call_expression`
   - `method_invocation`, `method_call`, `member_call_expression`
   - `invocation_expression`
   - `new_expression`, `object_creation_expression`
   - `macro_invocation` (Rust)
   - `scoped_call`
3. Extracts the callee identifier from the conventional field (`function`, `name`, `callee`, `method`, plus `macro` for `macro_invocation`).
4. Reduces qualified targets (`mod::Foo::bar`, `obj.foo.bar`, `pkg.module.helper`) to their **rightmost name segment**, which is the form the symbol index keys on.

`callees::run` now:
- skips non-code files outright (they have no symbols anyway),
- swaps `extract_identifiers(&body)` for `collect_callees(&content, lang, def.line, def.end_line)`,
- otherwise keeps the same dedup → paginate → emit pipeline.

## Smoke

Before (substring walk): `scry callees run` returned 600+ false positives across `bool`, `usize`, `Result`, plus dozens of identifiers from doc-comments. After:

```
$ scry callees run | head -8
clone     @ ./crates/fff-core/src/types.rs:100
clone     @ ./crates/fff-core/src/types.rs:236
contains  @ ./crates/fff-symbol/src/bloom.rs:67
contains  @ ./crates/fff-symbol/src/bloom.rs:182
emit      @ ./crates/fff-cli/src/commands/mod.rs:26
format    @ ./crates/fff-mcp/src/output.rs:165
is_empty  @ ./crates/fff-symbol/src/symbol_index.rs:54
is_empty  @ ./crates/fff-symbol/src/bloom.rs:170
```

All entries are real calls inside `run` bodies somewhere in the workspace.

## Tests

6 unit tests in `callees_resolve` cover:

- Rust: simple `foo()`, `bar(1,2)` calls.
- Rust: method (`obj.do_thing()`) + path (`crate::module::helper()`) reduce to rightmost name.
- Rust: macros (`println!`, `vec!`) are collected.
- Line-window filter: a call before the window is excluded; a call inside is kept.
- Python: `obj.do_thing()` and `pkg.mod.helper()` resolve to rightmost.
- TypeScript: `foo()`, `new Bar()`, and `obj.qux()` all collected.

`cargo build`, `cargo clippy -p fff-cli -- -D warnings`, `cargo fmt --check`, `cargo test -p fff-cli` (35 tests, 6 new) all clean.

## Review & Testing Checklist for Human

- [ ] Spot-check on a TypeScript / Python / Go file: pick a function with non-trivial calls and confirm the result matches what's actually called.
- [ ] Confirm the rightmost-name reduction is the right call. The alternative is "preserve qualified path" but that's a different feature (file-level deps, planned in a follow-up PR).

## Notes

- `fff-cli` now depends on the workspace `tree-sitter` crate. It was already pulled in transitively via `fff-symbol`, this just makes it direct so the resolver can drive its own `Parser`.
- Languages without a tree-sitter grammar in `outline_language` (Dockerfile, Make) skip silently — `collect_callees` returns `None` and the file is dropped from the body iteration. Consistent with the rest of scry.
