### PR TITLE
feat(scry): multi-hop callers BFS with hub guard

### DIFF
--- a/crates/fff-cli/src/commands/callers.rs
+++ b/crates/fff-cli/src/commands/callers.rs
@@ -1,7 +1,5 @@
-//! `scry callers <symbol>` — find lines that reference `symbol` outside of its
-//! own definition. The implementation is bloom-narrowed (via the engine's
-//! `BloomFilterCache`) and then confirms with a literal-text pass on each
-//! survivor.
+//! `scry callers <symbol>` — find call sites for `symbol`. With `--hops > 1`
+//! the search becomes a BFS over the caller graph.
 
 use std::path::Path;
 use std::time::SystemTime;
@@ -11,8 +9,11 @@ use clap::Parser;
 use serde::Serialize;
 
 use fff_engine::{Engine, PreFilterStack};
+use fff_symbol::lang::detect_file_type;
+use fff_symbol::types::FileType;
 
 use crate::cli::OutputFormat;
+use crate::commands::callers_bfs::{run_bfs, BfsConfig, CandidateFile};
 use crate::commands::pagination::{footer, Page};
 
 #[derive(Debug, Parser)]
@@ -27,18 +28,34 @@ pub struct Args {
     /// Skip this many hits before starting the page.
     #[arg(long, default_value_t = 0)]
     pub offset: usize,
+
+    /// How far to walk the caller graph. 1 = direct callers only. Capped at 5.
+    #[arg(long, default_value_t = 1)]
+    pub hops: u32,
+
+    /// Skip propagation when a single name produces more than this many hits
+    /// in one hop. Prevents popular helpers (clone, unwrap, …) from blowing
+    /// the BFS up.
+    #[arg(long, default_value_t = 50)]
+    pub hub_guard: usize,
 }
 
 #[derive(Debug, Serialize)]
-struct CallerHit {
-    path: String,
-    line: u32,
-    text: String,
+pub struct CallerHit {
+    pub path: String,
+    pub line: u32,
+    pub text: String,
+    pub depth: u32,
+    pub target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enclosing: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
 struct CallersOutput {
     name: String,
+    hops: u32,
+    hub_guard: usize,
     hits: Vec<CallerHit>,
     total: usize,
     offset: usize,
@@ -49,45 +66,75 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
     let engine = Engine::default();
     engine.index(root);
 
-    let definitions = engine.handles.symbols.lookup_exact(&args.name);
+    let files = super::walk_files(root);
+    let candidates: Vec<CandidateFile> = files
+        .iter()
+        .filter_map(|path| {
+            let meta = std::fs::metadata(path).ok()?;
+            let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+            let content = std::fs::read_to_string(path).ok()?;
+            let lang = match detect_file_type(path) {
+                FileType::Code(l) => Some(l),
+                _ => None,
+            };
+            Some(CandidateFile {
+                path: path.clone(),
+                mtime,
+                content,
+                lang,
+            })
+        })
+        .collect();
+
+    let hits = if args.hops <= 1 {
+        single_hop(&engine, &args.name, &candidates)
+    } else {
+        run_bfs(
+            &engine,
+            &args.name,
+            &candidates,
+            BfsConfig {
+                max_hops: args.hops,
+                hub_guard: args.hub_guard,
+            },
+        )
+    };
+
+    let page = Page::paginate(hits, args.offset, args.limit);
+    let payload = CallersOutput {
+        name: args.name.clone(),
+        hops: args.hops.clamp(1, 5),
+        hub_guard: args.hub_guard,
+        total: page.total,
+        offset: page.offset,
+        has_more: page.has_more,
+        hits: page.items,
+    };
+    super::emit(format, &payload, render_text)
+}
+
+fn single_hop(engine: &Engine, name: &str, candidates: &[CandidateFile]) -> Vec<CallerHit> {
+    let definitions = engine.handles.symbols.lookup_exact(name);
     let definition_paths: Vec<String> = definitions
         .iter()
         .map(|d| d.path.to_string_lossy().to_string())
         .collect();
 
     let stack = PreFilterStack::new(engine.handles.bloom.clone());
-    let files = super::walk_files(root);
-
-    let mut candidates: Vec<(std::path::PathBuf, SystemTime, String)> =
-        Vec::with_capacity(files.len());
-    for path in &files {
-        let Ok(meta) = std::fs::metadata(path) else {
-            continue;
-        };
-        let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
-        let Ok(content) = std::fs::read_to_string(path) else {
-            continue;
-        };
-        candidates.push((path.clone(), mtime, content));
-    }
-
-    let survivors = stack.confirm_symbol(
-        &candidates
-            .iter()
-            .map(|(p, m, c)| (p.clone(), *m, c.clone()))
-            .collect::<Vec<_>>(),
-        &args.name,
-    );
+    let confirm_input: Vec<(std::path::PathBuf, SystemTime, String)> = candidates
+        .iter()
+        .map(|c| (c.path.clone(), c.mtime, c.content.clone()))
+        .collect();
+    let survivors = stack.confirm_symbol(&confirm_input, name);
     let survivor_set: std::collections::HashSet<&std::path::Path> =
         survivors.iter().map(|s| s.path.as_path()).collect();
 
     let mut hits: Vec<CallerHit> = Vec::new();
-    for (path, _mtime, content) in &candidates {
-        if !survivor_set.contains(path.as_path()) {
+    for cf in candidates {
+        if !survivor_set.contains(cf.path.as_path()) {
             continue;
         }
-        let path_str = path.to_string_lossy().to_string();
-
+        let path_str = cf.path.to_string_lossy().to_string();
         let in_defn_file = definition_paths.contains(&path_str);
         let definition_lines: Vec<u32> = if in_defn_file {
             definitions
@@ -99,9 +146,9 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
             Vec::new()
         };
 
-        for (lineno, line) in content.lines().enumerate() {
+        for (lineno, line) in cf.content.lines().enumerate() {
             let lineno = (lineno + 1) as u32;
-            if !line.contains(&args.name) {
+            if !line.contains(name) {
                 continue;
             }
             if definition_lines.contains(&lineno) {
@@ -111,28 +158,32 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
                 path: path_str.clone(),
                 line: lineno,
                 text: line.to_string(),
+                depth: 1,
+                target: name.to_string(),
+                enclosing: None,
             });
         }
     }
+    hits
+}
 
-    let page = Page::paginate(hits, args.offset, args.limit);
-    let payload = CallersOutput {
-        name: args.name,
-        total: page.total,
-        offset: page.offset,
-        has_more: page.has_more,
-        hits: page.items,
-    };
-    super::emit(format, &payload, |p| {
-        let mut out = String::new();
-        for h in &p.hits {
+fn render_text(p: &CallersOutput) -> String {
+    let mut out = String::new();
+    for h in &p.hits {
+        if p.hops > 1 {
+            let encl = h.enclosing.as_deref().unwrap_or("?");
+            out.push_str(&format!(
+                "[d{}] {}:{}: {}  (in {}, calls {})\n",
+                h.depth, h.path, h.line, h.text, encl, h.target
+            ));
+        } else {
             out.push_str(&format!("{}:{}: {}\n", h.path, h.line, h.text));
         }
-        if p.total == 0 {
-            out.push_str("[no callers found]\n");
-        } else {
-            out.push_str(&footer(p.total, p.offset, p.hits.len(), p.has_more));
-        }
-        out
-    })
+    }
+    if p.total == 0 {
+        out.push_str("[no callers found]\n");
+    } else {
+        out.push_str(&footer(p.total, p.offset, p.hits.len(), p.has_more));
+    }
+    out
 }

--- a/crates/fff-cli/src/commands/callers_bfs.rs
+++ b/crates/fff-cli/src/commands/callers_bfs.rs
@@ -1,0 +1,216 @@
+//! Multi-hop BFS over the caller graph for `scry callers --hops N`.
+//!
+//! Each hop:
+//! 1. For every name in the current frontier, find direct call-site lines
+//!    using the same bloom-narrowed text scan that single-hop callers uses.
+//! 2. Map each hit to its enclosing symbol (function/method/class) via the
+//!    outline cache.
+//! 3. Add those enclosing symbols to the next frontier, modulo `hub_guard`:
+//!    if a single name produces more than `hub_guard` hits at this hop, its
+//!    enclosing symbols don't propagate further (but the hits still surface).
+//!
+//! The frontier is name-keyed, so a symbol that's defined in many places
+//! (e.g. trait methods) is searched once per hop regardless of definition
+//! count.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use fff_engine::{Engine, PreFilterStack};
+use fff_symbol::types::{Lang, OutlineEntry};
+
+use crate::commands::callers::CallerHit;
+
+pub struct BfsConfig {
+    pub max_hops: u32,
+    pub hub_guard: usize,
+}
+
+pub struct CandidateFile {
+    pub path: PathBuf,
+    pub mtime: SystemTime,
+    pub content: String,
+    pub lang: Option<Lang>,
+}
+
+pub fn run_bfs(
+    engine: &Engine,
+    initial: &str,
+    candidates: &[CandidateFile],
+    cfg: BfsConfig,
+) -> Vec<CallerHit> {
+    let stack = PreFilterStack::new(engine.handles.bloom.clone());
+    let mut visited: HashSet<String> = HashSet::new();
+    visited.insert(initial.to_string());
+    let mut frontier: Vec<String> = vec![initial.to_string()];
+    let mut all_hits: Vec<CallerHit> = Vec::new();
+
+    let confirm_input: Vec<(PathBuf, SystemTime, String)> = candidates
+        .iter()
+        .map(|c| (c.path.clone(), c.mtime, c.content.clone()))
+        .collect();
+
+    let max_hops = cfg.max_hops.clamp(1, 5);
+
+    for depth in 1..=max_hops {
+        if frontier.is_empty() {
+            break;
+        }
+
+        let mut next_set: HashSet<String> = HashSet::new();
+        let mut hub_for_name: HashMap<String, usize> = HashMap::new();
+
+        for name in &frontier {
+            let definitions = engine.handles.symbols.lookup_exact(name);
+            let definition_paths: HashSet<String> = definitions
+                .iter()
+                .map(|d| d.path.to_string_lossy().to_string())
+                .collect();
+
+            let survivors = stack.confirm_symbol(&confirm_input, name);
+            let survivor_set: HashSet<&std::path::Path> =
+                survivors.iter().map(|s| s.path.as_path()).collect();
+
+            let mut hits_for_name = 0usize;
+            let mut enclosings_this_name: Vec<String> = Vec::new();
+
+            for cf in candidates {
+                if !survivor_set.contains(cf.path.as_path()) {
+                    continue;
+                }
+                let path_str = cf.path.to_string_lossy().to_string();
+                let in_defn_file = definition_paths.contains(&path_str);
+                let definition_lines: Vec<u32> = if in_defn_file {
+                    definitions
+                        .iter()
+                        .filter(|d| d.path.to_string_lossy() == path_str)
+                        .map(|d| d.line)
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+
+                let outline = if let Some(lang) = cf.lang {
+                    engine
+                        .handles
+                        .outlines
+                        .get_or_compute(&cf.path, cf.mtime, &cf.content, lang)
+                } else {
+                    Vec::new()
+                };
+
+                for (lineno, line) in cf.content.lines().enumerate() {
+                    let lineno = (lineno + 1) as u32;
+                    if !line.contains(name) {
+                        continue;
+                    }
+                    if definition_lines.contains(&lineno) {
+                        continue;
+                    }
+                    let enclosing = enclosing_symbol(&outline, lineno);
+                    if let Some(ref e) = enclosing {
+                        enclosings_this_name.push(e.clone());
+                    }
+                    all_hits.push(CallerHit {
+                        path: path_str.clone(),
+                        line: lineno,
+                        text: line.to_string(),
+                        depth,
+                        target: name.clone(),
+                        enclosing,
+                    });
+                    hits_for_name += 1;
+                }
+            }
+
+            hub_for_name.insert(name.clone(), hits_for_name);
+            if hits_for_name <= cfg.hub_guard {
+                for e in enclosings_this_name {
+                    next_set.insert(e);
+                }
+            }
+        }
+
+        next_set.retain(|n| !visited.contains(n));
+        for n in &next_set {
+            visited.insert(n.clone());
+        }
+        frontier = next_set.into_iter().collect();
+    }
+
+    all_hits
+}
+
+pub fn enclosing_symbol(entries: &[OutlineEntry], line: u32) -> Option<String> {
+    fn walk(entries: &[OutlineEntry], line: u32) -> Option<&OutlineEntry> {
+        for e in entries {
+            if line < e.start_line || line > e.end_line {
+                continue;
+            }
+            if let Some(child) = walk(&e.children, line) {
+                return Some(child);
+            }
+            return Some(e);
+        }
+        None
+    }
+    walk(entries, line).map(|e| e.name.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fff_symbol::types::OutlineKind;
+
+    fn entry(
+        kind: OutlineKind,
+        name: &str,
+        start: u32,
+        end: u32,
+        children: Vec<OutlineEntry>,
+    ) -> OutlineEntry {
+        OutlineEntry {
+            kind,
+            name: name.to_string(),
+            start_line: start,
+            end_line: end,
+            signature: None,
+            children,
+            doc: None,
+        }
+    }
+
+    #[test]
+    fn enclosing_returns_innermost_symbol() {
+        let outer = entry(
+            OutlineKind::Class,
+            "Foo",
+            10,
+            40,
+            vec![entry(OutlineKind::Function, "bar", 20, 30, vec![])],
+        );
+        let outline = vec![outer];
+        assert_eq!(enclosing_symbol(&outline, 25), Some("bar".to_string()));
+    }
+
+    #[test]
+    fn enclosing_returns_outer_when_outside_inner() {
+        let outer = entry(
+            OutlineKind::Class,
+            "Foo",
+            10,
+            40,
+            vec![entry(OutlineKind::Function, "bar", 20, 30, vec![])],
+        );
+        let outline = vec![outer];
+        assert_eq!(enclosing_symbol(&outline, 35), Some("Foo".to_string()));
+    }
+
+    #[test]
+    fn enclosing_returns_none_when_outside_all() {
+        let outline = vec![entry(OutlineKind::Function, "bar", 20, 30, vec![])];
+        assert_eq!(enclosing_symbol(&outline, 5), None);
+        assert_eq!(enclosing_symbol(&outline, 50), None);
+    }
+}

--- a/crates/fff-cli/src/commands/mod.rs
+++ b/crates/fff-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod callees;
 pub mod callers;
+pub(crate) mod callers_bfs;
 pub(crate) mod dedup;
 pub mod dispatch;
 pub(crate) mod facets;


### PR DESCRIPTION
## Summary

Adds `--hops <N>` (1–5, default 1) and `--hub-guard <K>` (default 50) to `scry callers`. With `--hops 1` the command behaves exactly as before — direct callers only — so existing scripts keep working.

```
$ scry callers paginate --hops 2 --limit 5
[d1] ./crates/fff-cli/src/commands/callers.rs:103: …Page::paginate(hits, …);  (in run, calls paginate)
[d1] ./crates/fff-cli/src/commands/find.rs:43:     …Page::paginate(all, …);   (in run, calls paginate)
[d1] ./crates/fff-cli/src/commands/symbol.rs:82:   …Page::paginate(all_hits, …);  (in run, calls paginate)
[d1] ./crates/fff-cli/src/commands/callees.rs:88:  …Page::paginate(hits, …);  (in run, calls paginate)
[d2] ./crates/fff-core/src/file_picker.rs:1822:    walker.run(|| {           (in ?, calls run)
[1-5 of 85] — next: --offset 5
```

## How the BFS works

Each hop:

1. For every name in the current frontier, find direct call-site lines using the existing single-hop pipeline (bloom-narrowed survivors → literal-text scan → exclude definition lines).
2. Map each hit to its enclosing symbol via `OutlineCache::get_or_compute`.
3. Add those enclosing names to the next hop's frontier.

`hub_guard` controls which names propagate. If a single name produces more than `hub_guard` hits in one hop, it's treated as a hub (think `unwrap`, `clone`, `to_string`). Its hits still surface, but the BFS doesn't expand past them so `callers --hops 5` on an obscure symbol stays tractable.

## CLI surface

| flag | default | meaning |
|---|---|---|
| `--hops` | 1 | how far to walk the caller graph (1–5) |
| `--hub-guard` | 50 | per-hop per-name hit cap before treating as hub |
| `--limit` | 100 | hits per page (existing) |
| `--offset` | 0 | pagination offset (existing) |

`CallerHit` gains `depth`, `target`, and an optional `enclosing`. `CallersOutput` adds `hops` and `hub_guard` so chained queries can pin down what produced a result. JSON shape:

```json
{
  "name": "paginate",
  "hops": 2,
  "hub_guard": 50,
  "hits": [
    { "path": "...", "line": 103, "text": "...", "depth": 1, "target": "paginate", "enclosing": "run" },
    { "path": "...", "line": 1822, "text": "...", "depth": 2, "target": "run" }
  ],
  "total": 85,
  "offset": 0,
  "has_more": true
}
```

Text rendering at `hops > 1` prefixes each line with `[d<N>]` and appends `(in <enclosing>, calls <target>)`; at `hops == 1` the single-hop format is preserved verbatim.

## Tests

3 unit tests in `callers_bfs::tests` cover the outline walk that finds the enclosing symbol:

- Returns the innermost match (`bar` inside class `Foo`, line 25 → `bar`).
- Falls back to the outer when the line is in the outer but not the inner (line 35 → `Foo`).
- Returns `None` when the line is outside every entry.

`cargo build`, `cargo clippy -p fff-cli --tests -- -D warnings`, `cargo fmt --check`, `cargo test -p fff-cli` (32 tests) all clean. Smoke on this repo: `callers paginate --hops 2 --limit 15` finishes in ~170ms over ~300 files.

## Review & Testing Checklist for Human

- [ ] Run on a target you know — confirm hop-1 results match what you'd get with the old command.
- [ ] Try a popular helper (e.g. `clone`, `unwrap`) at `--hops 3` and confirm the hub guard kicks in (depth-2 results should be sparse).
- [ ] JSON output: confirm `depth` / `target` / `enclosing` give you what you need for chained MCP queries.

## Notes

- The hop-1 pipeline is unchanged; the BFS is opt-in via `--hops > 1`.
- Substring matching still matches `run` inside `running` etc. — that's a known limitation of the single-hop scan and a separate cleanup.
- Files outside `code` languages (Dockerfile, Make, JSON, …) are scanned for hits but skipped for outline-based enclosing resolution, so their hits show `enclosing: null`.
