### PR TITLE
feat(scry): codebase fingerprinting / overview command

### DIFF
--- a/crates/fff-cli/src/cli.rs
+++ b/crates/fff-cli/src/cli.rs
@@ -66,6 +66,9 @@ pub enum Command {
     /// Build / refresh the on-disk indexes (Bigram, Bloom, Symbol, Outline).
     Index(commands::index::Args),
 
+    /// High-signal summary of the workspace (languages, top symbols, …).
+    Overview(commands::overview::Args),
+
     /// Run as MCP server over stdio (replaces agent built-ins Grep/Glob/Read).
     Mcp(commands::mcp::Args),
 }
@@ -88,6 +91,7 @@ impl Cli {
             Command::Callees(a) => commands::callees::run(a, &root, self.format),
             Command::Dispatch(a) => commands::dispatch::run(a, &root, self.format),
             Command::Index(a) => commands::index::run(a, &root, self.format),
+            Command::Overview(a) => commands::overview::run(a, &root, self.format),
             Command::Mcp(a) => commands::mcp::run(a, &root),
         }
     }

--- a/crates/fff-cli/src/commands/mod.rs
+++ b/crates/fff-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod index;
 pub mod mcp;
 pub mod outline;
 pub(crate) mod outline_format;
+pub mod overview;
 pub(crate) mod pagination;
 pub mod read;
 pub mod symbol;

--- a/crates/fff-cli/src/commands/overview.rs
+++ b/crates/fff-cli/src/commands/overview.rs
@@ -1,0 +1,384 @@
+//! `scry overview` — high-signal summary of the workspace for agents.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+use std::time::SystemTime;
+
+use anyhow::Result;
+use clap::Parser;
+use serde::Serialize;
+
+use fff_engine::Engine;
+use fff_symbol::lang::detect_file_type;
+use fff_symbol::types::{FileType, Lang};
+
+use crate::cli::OutputFormat;
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// How many language buckets to include in the breakdown.
+    #[arg(long, default_value_t = 10)]
+    pub top_languages: usize,
+
+    /// How many of the most-defined symbol names to include.
+    #[arg(long, default_value_t = 15)]
+    pub top_symbols: usize,
+
+    /// How many entry-point candidates to surface.
+    #[arg(long, default_value_t = 10)]
+    pub top_entrypoints: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct LanguageStat {
+    lang: String,
+    files: usize,
+    code_lines: usize,
+    bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct SymbolStat {
+    name: String,
+    definitions: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct OverviewOutput {
+    root: String,
+    files: usize,
+    code_files: usize,
+    code_lines: usize,
+    bytes: u64,
+    fingerprint: String,
+    languages: Vec<LanguageStat>,
+    build_files: Vec<String>,
+    entrypoints: Vec<String>,
+    top_symbols: Vec<SymbolStat>,
+}
+
+pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
+    let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+
+    let engine = Engine::default();
+    engine.index(&root);
+
+    let files = super::walk_files(&root);
+
+    let mut total_files = 0usize;
+    let mut code_files = 0usize;
+    let mut total_lines = 0usize;
+    let mut total_bytes = 0u64;
+    let mut lang_buckets: HashMap<Lang, LangBucket> = HashMap::new();
+    let mut build_files: Vec<String> = Vec::new();
+    let mut entrypoints: Vec<String> = Vec::new();
+    let mut fingerprint_input: Vec<(String, u64, SystemTime)> = Vec::new();
+
+    for path in &files {
+        let Ok(meta) = std::fs::metadata(path) else {
+            continue;
+        };
+        let size = meta.len();
+        total_bytes += size;
+        let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+        total_files += 1;
+
+        let rel = path
+            .strip_prefix(&root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .to_string();
+
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if is_build_file(name) {
+                build_files.push(rel.clone());
+            }
+            if is_entrypoint(name, &rel) {
+                entrypoints.push(rel.clone());
+            }
+        }
+
+        if let FileType::Code(lang) = detect_file_type(path) {
+            code_files += 1;
+            let lines = std::fs::read_to_string(path)
+                .map(|c| c.lines().count())
+                .unwrap_or(0);
+            total_lines += lines;
+            let bucket = lang_buckets.entry(lang).or_default();
+            bucket.files += 1;
+            bucket.code_lines += lines;
+            bucket.bytes += size;
+        }
+
+        fingerprint_input.push((rel, size, mtime));
+    }
+
+    let mut languages: Vec<LanguageStat> = lang_buckets
+        .into_iter()
+        .map(|(lang, b)| LanguageStat {
+            lang: format!("{lang:?}"),
+            files: b.files,
+            code_lines: b.code_lines,
+            bytes: b.bytes,
+        })
+        .collect();
+    languages.sort_by(|a, b| b.code_lines.cmp(&a.code_lines).then(a.lang.cmp(&b.lang)));
+    languages.truncate(args.top_languages);
+
+    build_files.sort();
+    entrypoints.sort();
+    entrypoints.truncate(args.top_entrypoints);
+
+    let top_symbols = collect_top_symbols(&engine, args.top_symbols);
+
+    let fingerprint = fingerprint(&fingerprint_input);
+
+    let payload = OverviewOutput {
+        root: root.to_string_lossy().to_string(),
+        files: total_files,
+        code_files,
+        code_lines: total_lines,
+        bytes: total_bytes,
+        fingerprint,
+        languages,
+        build_files,
+        entrypoints,
+        top_symbols,
+    };
+    super::emit(format, &payload, render_text)
+}
+
+#[derive(Default)]
+struct LangBucket {
+    files: usize,
+    code_lines: usize,
+    bytes: u64,
+}
+
+fn is_build_file(name: &str) -> bool {
+    matches!(
+        name,
+        "Cargo.toml"
+            | "Cargo.lock"
+            | "pyproject.toml"
+            | "setup.py"
+            | "setup.cfg"
+            | "package.json"
+            | "package-lock.json"
+            | "yarn.lock"
+            | "bun.lockb"
+            | "pnpm-lock.yaml"
+            | "go.mod"
+            | "go.sum"
+            | "pom.xml"
+            | "build.gradle"
+            | "build.gradle.kts"
+            | "settings.gradle"
+            | "settings.gradle.kts"
+            | "Gemfile"
+            | "Gemfile.lock"
+            | "composer.json"
+            | "composer.lock"
+            | "Makefile"
+            | "CMakeLists.txt"
+            | "Dockerfile"
+            | "flake.nix"
+            | "shell.nix"
+            | "default.nix"
+            | "mix.exs"
+    )
+}
+
+fn is_entrypoint(name: &str, rel: &str) -> bool {
+    if matches!(
+        name,
+        "main.rs"
+            | "lib.rs"
+            | "main.py"
+            | "__main__.py"
+            | "app.py"
+            | "manage.py"
+            | "main.go"
+            | "Main.java"
+            | "Application.java"
+            | "Program.cs"
+            | "main.kt"
+            | "main.swift"
+    ) {
+        return true;
+    }
+    let lower = name.to_lowercase();
+    if lower == "index.ts" || lower == "index.tsx" || lower == "index.js" || lower == "index.mjs" {
+        return rel.starts_with("src/") || rel.contains("/src/") || rel.split('/').count() <= 2;
+    }
+    false
+}
+
+fn collect_top_symbols(engine: &Engine, n: usize) -> Vec<SymbolStat> {
+    let all = engine.handles.symbols.lookup_prefix("");
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for (name, _loc) in all {
+        *counts.entry(name).or_insert(0) += 1;
+    }
+    let mut ranked: Vec<(String, usize)> = counts.into_iter().collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    ranked
+        .into_iter()
+        .take(n)
+        .map(|(name, definitions)| SymbolStat { name, definitions })
+        .collect()
+}
+
+fn fingerprint(items: &[(String, u64, SystemTime)]) -> String {
+    let mut sorted: Vec<&(String, u64, SystemTime)> = items.iter().collect();
+    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut state = FnvHasher::new();
+    for (path, size, mtime) in sorted {
+        for b in path.as_bytes() {
+            state.update(*b);
+        }
+        state.update(0);
+        for b in size.to_le_bytes() {
+            state.update(b);
+        }
+        let secs = mtime
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        for b in secs.to_le_bytes() {
+            state.update(b);
+        }
+    }
+    format!("{:016x}", state.finish())
+}
+
+struct FnvHasher {
+    h: u64,
+}
+
+impl FnvHasher {
+    fn new() -> Self {
+        Self {
+            h: 0xcbf29ce484222325,
+        }
+    }
+    fn update(&mut self, b: u8) {
+        self.h ^= b as u64;
+        self.h = self.h.wrapping_mul(0x100000001b3);
+    }
+    fn finish(self) -> u64 {
+        self.h
+    }
+}
+
+fn render_text(p: &OverviewOutput) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("# overview: {}\n", p.root));
+    out.push_str(&format!("fingerprint   {}\n", p.fingerprint));
+    out.push_str(&format!(
+        "files         {}  (code: {}, total LOC ~{})\n",
+        p.files, p.code_files, p.code_lines
+    ));
+    out.push_str(&format!("bytes         {}\n", humanize_bytes(p.bytes)));
+
+    if !p.languages.is_empty() {
+        out.push_str("\n## languages\n");
+        for l in &p.languages {
+            out.push_str(&format!(
+                "  {:<14} {:>4} files  ~{} LOC\n",
+                l.lang, l.files, l.code_lines
+            ));
+        }
+    }
+
+    if !p.build_files.is_empty() {
+        out.push_str("\n## build files\n");
+        for f in &p.build_files {
+            out.push_str(&format!("  {f}\n"));
+        }
+    }
+
+    if !p.entrypoints.is_empty() {
+        out.push_str("\n## entrypoints\n");
+        for f in &p.entrypoints {
+            out.push_str(&format!("  {f}\n"));
+        }
+    }
+
+    if !p.top_symbols.is_empty() {
+        out.push_str("\n## top symbols\n");
+        for s in &p.top_symbols {
+            out.push_str(&format!("  {:<24} {} defs\n", s.name, s.definitions));
+        }
+    }
+    out
+}
+
+fn humanize_bytes(b: u64) -> String {
+    const K: u64 = 1024;
+    if b < K {
+        format!("{b}B")
+    } else if b < K * K {
+        format!("{:.1}K", b as f64 / K as f64)
+    } else if b < K * K * K {
+        format!("{:.1}M", b as f64 / (K * K) as f64)
+    } else {
+        format!("{:.1}G", b as f64 / (K * K * K) as f64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_files_match_known_names() {
+        assert!(is_build_file("Cargo.toml"));
+        assert!(is_build_file("package.json"));
+        assert!(is_build_file("pyproject.toml"));
+        assert!(is_build_file("Dockerfile"));
+        assert!(!is_build_file("README.md"));
+        assert!(!is_build_file("Cargo.txt"));
+    }
+
+    #[test]
+    fn entrypoints_pick_known_names() {
+        assert!(is_entrypoint("main.rs", "src/main.rs"));
+        assert!(is_entrypoint("lib.rs", "src/lib.rs"));
+        assert!(is_entrypoint("main.py", "app/main.py"));
+        assert!(!is_entrypoint("util.rs", "src/util.rs"));
+    }
+
+    #[test]
+    fn entrypoints_index_only_at_src_or_top_level() {
+        assert!(is_entrypoint("index.ts", "src/index.ts"));
+        assert!(is_entrypoint("index.ts", "index.ts"));
+        assert!(is_entrypoint("index.ts", "packages/foo/src/index.ts"));
+        assert!(!is_entrypoint("index.ts", "node_modules/x/y/index.ts"));
+    }
+
+    #[test]
+    fn fingerprint_is_deterministic_and_size_sensitive() {
+        let mtime = SystemTime::UNIX_EPOCH;
+        let a = vec![("a.rs".to_string(), 10u64, mtime)];
+        let b = vec![("a.rs".to_string(), 10u64, mtime)];
+        assert_eq!(fingerprint(&a), fingerprint(&b));
+
+        let c = vec![("a.rs".to_string(), 11u64, mtime)];
+        assert_ne!(fingerprint(&a), fingerprint(&c));
+    }
+
+    #[test]
+    fn fingerprint_is_order_independent() {
+        let mtime = SystemTime::UNIX_EPOCH;
+        let a = vec![
+            ("a.rs".to_string(), 10u64, mtime),
+            ("b.rs".to_string(), 20u64, mtime),
+        ];
+        let b = vec![
+            ("b.rs".to_string(), 20u64, mtime),
+            ("a.rs".to_string(), 10u64, mtime),
+        ];
+        assert_eq!(fingerprint(&a), fingerprint(&b));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `scry overview` — a high-signal summary of the workspace that bundles five separate queries into one shot. Useful as the first call an agent makes when it meets an unfamiliar codebase, or as a cheap way to detect "is this the same workspace state I saw last time?" before re-running expensive queries.

```
$ scry --root . overview
# overview: /home/ubuntu/repos/scry
fingerprint   ddb2e425efd86d57
files         248  (code: 161, total LOC ~55832)
bytes         2.8M

## languages
  Rust          132 files  ~45088 LOC
  TypeScript     22 files   ~8555 LOC
  C               1 files   ~1320 LOC
  Python          2 files    ~399 LOC
  JavaScript      3 files    ~312 LOC
  Make            1 files    ~158 LOC

## build files
  Cargo.toml
  Makefile
  flake.nix
  package.json
  packages/.../package.json
  …

## entrypoints
  crates/fff-cli/src/main.rs
  crates/fff-core/src/lib.rs
  crates/fff-engine/src/lib.rs
  crates/fff-mcp/src/main.rs
  …

## top symbols
  result    53 defs
  tests     43 defs
  new       42 defs
  guard     27 defs
  main      22 defs
  …
```

## Why this exists

scry already exposes the building blocks: language detection, symbol index, walker. Without a top-level summary an agent has to chain five queries (`find Cargo.toml`, `find main.rs`, `symbol *`, `index --stats`, …) just to know what kind of project it's looking at. `overview` is one syscall.

The `fingerprint` field is FNV-1a over sorted `(path, size, mtime)` tuples for every walked file. It's deterministic and order-independent, so a caller can cache responses keyed by fingerprint and skip work when nothing has changed.

## What it surfaces

- **stats**: total files, code files, total LOC, total bytes
- **fingerprint**: 16-hex FNV-1a digest over `(path, size, mtime)` tuples (sorted, order-independent)
- **languages**: per-language breakdown (files + code lines + bytes), sorted by LOC, capped at `--top-languages`
- **build files**: known package / build manifest files (`Cargo.toml`, `package.json`, `pyproject.toml`, `flake.nix`, `Makefile`, `Dockerfile`, `pom.xml`, `go.mod`, `Gemfile`, `mix.exs`, …)
- **entrypoints**: candidate main files (`main.rs`, `lib.rs`, `main.py`, `app.py`, `index.ts` only at top-level or under `src/`, …), capped at `--top-entrypoints`
- **top symbols**: most-defined symbol names from the existing engine `SymbolIndex`, ranked by count, capped at `--top-symbols`

## CLI surface

| flag | default | meaning |
|---|---|---|
| `--top-languages` | 10 | language buckets in the breakdown |
| `--top-symbols` | 15 | most-defined symbols to surface |
| `--top-entrypoints` | 10 | entrypoint candidates to surface |

JSON output (`--format json`) emits all fields in a single serialisable struct, ready for chained queries.

## Tests

5 new unit tests:

- `is_build_file` matches known names (`Cargo.toml`, `package.json`, `pyproject.toml`, `Dockerfile`) and rejects near-misses.
- `is_entrypoint` matches known names (`main.rs`, `lib.rs`, `main.py`) and rejects ordinary files.
- `is_entrypoint("index.ts", path)` only fires at top-level or under a `src/` directory (so a stray `node_modules/x/y/index.ts` doesn't get picked).
- `fingerprint` is deterministic and reacts to size changes.
- `fingerprint` is order-independent (re-shuffling the input vector produces the same digest).

`cargo build`, `cargo clippy -p fff-cli --tests -- -D warnings`, `cargo fmt --check`, `cargo test -p fff-cli` (34 tests, 5 new) all clean.

## Review & Testing Checklist for Human

- [ ] Run on a real polyglot repo and confirm the language breakdown matches reality.
- [ ] Diff `fingerprint` between two runs, then `touch` a file and confirm it changes.
- [ ] Confirm `top symbols` are useful — they should reflect API surface, not noise.
- [ ] JSON shape: confirm `fingerprint` / `top_symbols` give you what you need for cache-keying.

## Notes

- LOC counting uses raw `lines().count()` on UTF-8-decoded content. It's a rough metric (counts blank/comment lines too), in line with how `scry map` does its byte/token estimate.
- Top symbols come from `engine.handles.symbols.lookup_prefix("")`, so the command reuses whatever symbol index is already warm from a prior `scry index` / `scry symbol` / `scry callers` run.
- Entrypoint detection for `index.ts` is intentionally narrow (top-level or under `src/`) to avoid false positives from `node_modules/` and similar fixture trees.
