### PR TITLE
feat(scry): B0 — read default outline + outline --style agent

### DIFF
--- a/crates/fff-cli/assets/AGENT_GUIDE.md
+++ b/crates/fff-cli/assets/AGENT_GUIDE.md
@@ -47,8 +47,19 @@ Content search across the project. Powered by `ripgrep` semantics for
 gitignore handling.
 
 ### `read <target>`
-Read a file, optionally with a `path:line` suffix to highlight a
-span. Output is truncated to a token budget.
+Read a file. Default emits the **agent-style outline** (header +
+section list + footer hint) so agents can plan a follow-up drill
+without pulling the full body. Pass `--full` for raw contents, or
+use `path:line` / `--section` to drill straight into a structural
+section.
+
+Routing:
+* `read <path>` — outline default (code files only; non-code files
+  fall through to full body).
+* `read <path>:<N>` — structural section read at line `N`.
+* `read <path> --section` (combined with `path:N`) — same as above but
+  errors out if the line isn't supplied, useful in scripts.
+* `read <path> --full` — whole file body (legacy default).
 
 * `--budget <N>` — total token budget (default 25000). Effective byte
   cap ≈ `tokens × 0.85 × 4`; the remaining ≈15% is reserved for the
@@ -61,10 +72,12 @@ span. Output is truncated to a token budget.
 Tree-sitter outline of a single file: top-level functions, classes,
 structs, imports, and their immediate children where applicable.
 
-* `--style tabular|markdown|structured` — text rendering. `tabular`
-  (default) is fixed-width columns; `markdown` is nested bullets with
-  backticked names and signatures; `structured` is an ASCII tree
-  (`├─` / `└─`).
+* `--style agent|tabular|markdown|structured` — text rendering.
+  `agent` (default) is the dense, agent-friendly form: header line
+  with file totals, `[A-B]` left column, bundled-imports row, indented
+  signatures, and a `> Next:` drill hint. `tabular` is fixed-width
+  columns (KIND/NAME/LINES/SIGNATURE); `markdown` is nested bullets;
+  `structured` is an ASCII tree (`├─` / `└─`).
 * JSON output (`--format json`) is independent of `--style` and emits
   the entry tree directly with `kind`, `name`, `start_line`,
   `end_line`, `signature`, `children`.

--- a/crates/fff-cli/src/commands/outline.rs
+++ b/crates/fff-cli/src/commands/outline.rs
@@ -6,13 +6,16 @@ use serde::Serialize;
 
 use fff_symbol::lang::detect_file_type;
 use fff_symbol::outline::get_outline_entries;
-use fff_symbol::types::{FileType, OutlineEntry, OutlineKind};
+use fff_symbol::types::{estimate_tokens, FileType, OutlineEntry, OutlineKind};
 
 use crate::cli::OutputFormat;
-use crate::commands::outline_format;
+use crate::commands::outline_format::{self, AgentHeader};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum Style {
+    /// Agent-friendly default: header line, `[A-B]` left column, bundled
+    /// imports, indented signatures, and a `> Next:` drill hint.
+    Agent,
     Markdown,
     Structured,
     Tabular,
@@ -24,7 +27,7 @@ pub struct Args {
     pub path: String,
 
     /// Text rendering style. Ignored when --format=json.
-    #[arg(long, value_enum, default_value_t = Style::Tabular)]
+    #[arg(long, value_enum, default_value_t = Style::Agent)]
     pub style: Style,
 }
 
@@ -101,9 +104,44 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
         entries: entries.iter().map(OutlineEntryDto::from_entry).collect(),
     };
 
+    let display_path = args.path.clone();
+    let total_lines = content.lines().count() as u64;
+    let total_tokens = estimate_tokens(content.len() as u64);
+
     super::emit(format, &payload, |_| match args.style {
+        Style::Agent => outline_format::agent(
+            &entries,
+            AgentHeader {
+                path: &display_path,
+                lines: total_lines,
+                tokens: total_tokens,
+            },
+        ),
         Style::Markdown => outline_format::markdown(&entries),
         Style::Structured => outline_format::structured(&entries),
         Style::Tabular => outline_format::tabular(&entries),
     })
+}
+
+/// Library-style helper: render the agent outline for a path. Used by
+/// `scry read` when no flags steer it elsewhere.
+pub fn render_agent(path: &Path, display_path: &str) -> Result<String> {
+    let ft = detect_file_type(path);
+    let lang = match ft {
+        FileType::Code(l) => l,
+        _ => return Err(anyhow!("not a code file: {}", path.display())),
+    };
+    let content =
+        std::fs::read_to_string(path).map_err(|e| anyhow!("failed to read {}: {e}", path.display()))?;
+    let entries = get_outline_entries(&content, lang);
+    let total_lines = content.lines().count() as u64;
+    let total_tokens = estimate_tokens(content.len() as u64);
+    Ok(outline_format::agent(
+        &entries,
+        AgentHeader {
+            path: display_path,
+            lines: total_lines,
+            tokens: total_tokens,
+        },
+    ))
 }

--- a/crates/fff-cli/src/commands/outline.rs
+++ b/crates/fff-cli/src/commands/outline.rs
@@ -131,8 +131,8 @@ pub fn render_agent(path: &Path, display_path: &str) -> Result<String> {
         FileType::Code(l) => l,
         _ => return Err(anyhow!("not a code file: {}", path.display())),
     };
-    let content =
-        std::fs::read_to_string(path).map_err(|e| anyhow!("failed to read {}: {e}", path.display()))?;
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| anyhow!("failed to read {}: {e}", path.display()))?;
     let entries = get_outline_entries(&content, lang);
     let total_lines = content.lines().count() as u64;
     let total_tokens = estimate_tokens(content.len() as u64);

--- a/crates/fff-cli/src/commands/outline_format.rs
+++ b/crates/fff-cli/src/commands/outline_format.rs
@@ -1,13 +1,204 @@
-// Three text renderings of an outline tree:
+// Four text renderings of an outline tree:
 //
+// * agent — header + `[A-B]` left column + bundled imports + footer hint;
+//   the dense, agent-friendly default.
 // * markdown — nested bullet list, `- kind ` ``name`` ` (start-end)`
 // * structured — ASCII tree with ├─ / └─ branch glyphs
 // * tabular — fixed-width columns: KIND, NAME, LINES, SIGNATURE
 //
-// All three accept the same `&[OutlineEntry]` and return a `String` that
-// always ends with a trailing newline (or is empty).
+// All renderers accept `&[OutlineEntry]` and return a `String` that always
+// ends with a trailing newline (or is empty for the legacy renderers).
 
 use fff_symbol::types::{OutlineEntry, OutlineKind};
+
+/// Header metadata accompanying the agent-style outline. `path` is whatever
+/// caller wants to display (relative or absolute); `lines` and `tokens` are
+/// the file's totals before any filtering.
+pub(crate) struct AgentHeader<'a> {
+    pub path: &'a str,
+    pub lines: u64,
+    pub tokens: u64,
+}
+
+pub(crate) fn agent(entries: &[OutlineEntry], header: AgentHeader<'_>) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# {} ({} lines, {} tokens) [outline]\n\n",
+        header.path,
+        header.lines,
+        format_tokens(header.tokens),
+    ));
+
+    if entries.is_empty() {
+        out.push_str("(no symbols)\n");
+        return out;
+    }
+
+    let range_width = compute_range_width(entries, 0);
+    let imports_taken = render_imports_bundle(entries, &mut out, range_width);
+    for entry in &entries[imports_taken..] {
+        push_agent_entry(&mut out, entry, 0, range_width);
+    }
+
+    out.push_str("\n> Next: drill into a symbol with --section <name> or a line range\n");
+    out
+}
+
+fn format_tokens(tokens: u64) -> String {
+    if tokens >= 1000 {
+        let k = (tokens as f64) / 1000.0;
+        format!("~{:.1}k", k)
+    } else {
+        format!("~{}", tokens)
+    }
+}
+
+fn compute_range_width(entries: &[OutlineEntry], depth: usize) -> usize {
+    let mut max = 0;
+    for e in entries {
+        let w = depth * 2 + range_token(e).len();
+        if w > max {
+            max = w;
+        }
+        let inner = compute_range_width(&e.children, depth + 1);
+        if inner > max {
+            max = inner;
+        }
+    }
+    max
+}
+
+fn range_token(e: &OutlineEntry) -> String {
+    format!("[{}-{}]", e.start_line, e.end_line)
+}
+
+fn push_agent_entry(
+    out: &mut String,
+    e: &OutlineEntry,
+    depth: usize,
+    range_width: usize,
+) {
+    let indent = "  ".repeat(depth);
+    let range = range_token(e);
+    let visible = indent.len() + range.len();
+    let pad = " ".repeat(range_width.saturating_sub(visible) + 3);
+
+    out.push_str(&indent);
+    out.push_str(&range);
+    out.push_str(&pad);
+    out.push_str(kind_label(e.kind));
+    out.push(' ');
+    out.push_str(&e.name);
+    out.push('\n');
+
+    if let Some(sig) = e.signature.as_ref() {
+        let trimmed = sig.trim();
+        let head = format!("{} {}", kind_label(e.kind), e.name);
+        if !trimmed.is_empty() && trimmed != head {
+            let col = range_width + 3;
+            out.push_str(&" ".repeat(col));
+            out.push_str(trimmed);
+            out.push('\n');
+        }
+    }
+
+    for c in &e.children {
+        push_agent_entry(out, c, depth + 1, range_width);
+    }
+}
+
+/// Bundle leading consecutive imports into a single line: `[A-B] imports: a, b(2), c`.
+/// Returns the number of entries consumed.
+fn render_imports_bundle(
+    entries: &[OutlineEntry],
+    out: &mut String,
+    range_width: usize,
+) -> usize {
+    let count = entries
+        .iter()
+        .take_while(|e| matches!(e.kind, OutlineKind::Import))
+        .count();
+    if count == 0 {
+        return 0;
+    }
+
+    let first = &entries[0];
+    let last = &entries[count - 1];
+    let mut counts: Vec<(String, usize)> = Vec::new();
+    for e in &entries[..count] {
+        let src = parse_import_source(e.signature.as_deref().unwrap_or(""))
+            .unwrap_or_else(|| e.name.clone());
+        if let Some((_, c)) = counts.iter_mut().find(|(k, _)| k == &src) {
+            *c += 1;
+        } else {
+            counts.push((src, 1));
+        }
+    }
+    let parts: Vec<String> = counts
+        .into_iter()
+        .map(|(s, c)| if c > 1 { format!("{s}({c})") } else { s })
+        .collect();
+
+    let range = format!("[{}-{}]", first.start_line, last.end_line);
+    let pad = " ".repeat(range_width.saturating_sub(range.len()) + 3);
+    out.push_str(&range);
+    out.push_str(&pad);
+    out.push_str("imports: ");
+    out.push_str(&parts.join(", "));
+    out.push('\n');
+    count
+}
+
+/// Try to extract the imported module name from an import statement's first
+/// line. Handles JS/TS (`from 'x'` / `require('x')`), Python (`from x import`,
+/// `import x`), Rust (`use a::b::c;` → first segment), and bare quoted forms.
+/// Falls back to `None` when the shape isn't recognised.
+fn parse_import_source(sig: &str) -> Option<String> {
+    let s = sig.trim();
+    if s.is_empty() {
+        return None;
+    }
+
+    // Quoted module name (most JS/TS, ES `import 'x'`, CJS `require('x')`).
+    for q in ['"', '\''] {
+        if let Some(start) = s.find(q) {
+            if let Some(end_rel) = s[start + 1..].find(q) {
+                let inner = &s[start + 1..start + 1 + end_rel];
+                if !inner.is_empty() {
+                    return Some(inner.to_string());
+                }
+            }
+        }
+    }
+
+    // Python `from X import ...`
+    if let Some(rest) = s.strip_prefix("from ") {
+        if let Some(token) = rest.split_whitespace().next() {
+            return Some(token.to_string());
+        }
+    }
+
+    // Python `import X`, Java `import X.Y;`
+    if let Some(rest) = s.strip_prefix("import ") {
+        if let Some(token) = rest.split_whitespace().next() {
+            return Some(token.trim_end_matches(';').to_string());
+        }
+    }
+
+    // Rust `use a::b::c;` — group by crate root.
+    if let Some(rest) = s.strip_prefix("use ") {
+        let head = rest
+            .split(['{', ';', ' '])
+            .next()
+            .unwrap_or(rest);
+        let root = head.split("::").next().unwrap_or(head);
+        if !root.is_empty() {
+            return Some(root.to_string());
+        }
+    }
+
+    None
+}
 
 pub(crate) fn markdown(entries: &[OutlineEntry]) -> String {
     let mut out = String::new();
@@ -153,7 +344,7 @@ fn kind_label(k: OutlineKind) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{kind_label, markdown, structured, tabular};
+    use super::{agent, kind_label, markdown, parse_import_source, structured, tabular, AgentHeader};
     use fff_symbol::types::{OutlineEntry, OutlineKind};
 
     fn entry(kind: OutlineKind, name: &str, start: u32, end: u32) -> OutlineEntry {
@@ -271,6 +462,157 @@ mod tests {
         let out = tabular(&[parent]);
         // Child name should be prefixed with two spaces of indent.
         assert!(out.contains("  field"));
+    }
+
+    #[test]
+    fn agent_header_renders_path_lines_and_tokens() {
+        let entries = vec![entry(OutlineKind::Function, "main", 1, 5)];
+        let out = agent(
+            &entries,
+            AgentHeader {
+                path: "src/foo.rs",
+                lines: 5,
+                tokens: 42,
+            },
+        );
+        assert!(out.starts_with("# src/foo.rs (5 lines, ~42 tokens) [outline]\n\n"));
+        assert!(out.contains("function main"));
+        assert!(out.trim_end().ends_with("--section <name> or a line range"));
+    }
+
+    #[test]
+    fn agent_renders_kilo_token_count_with_one_decimal() {
+        let entries = vec![entry(OutlineKind::Function, "f", 1, 1)];
+        let out = agent(
+            &entries,
+            AgentHeader {
+                path: "src/big.ts",
+                lines: 258,
+                tokens: 3_400,
+            },
+        );
+        assert!(out.starts_with("# src/big.ts (258 lines, ~3.4k tokens) [outline]"));
+    }
+
+    #[test]
+    fn agent_bundles_consecutive_imports_into_one_line() {
+        let mut imp1 = entry(OutlineKind::Import, "express", 1, 1);
+        imp1.signature = Some("import express from 'express';".into());
+        let mut imp2 = entry(OutlineKind::Import, "jwt", 2, 2);
+        imp2.signature = Some("import jwt from 'jsonwebtoken';".into());
+        let mut imp3 = entry(OutlineKind::Import, "router", 3, 3);
+        imp3.signature = Some("const Router = require('express');".into());
+        let func = entry(OutlineKind::Function, "handle", 5, 10);
+        let out = agent(
+            &[imp1, imp2, imp3, func],
+            AgentHeader {
+                path: "app.ts",
+                lines: 10,
+                tokens: 80,
+            },
+        );
+        // Imports collapsed; `express` deduped to count 2.
+        assert!(
+            out.contains("imports: express(2), jsonwebtoken"),
+            "output:\n{out}"
+        );
+        // Range covers the whole import block.
+        assert!(out.contains("[1-3]"));
+        // Function still rendered after the bundle.
+        assert!(out.contains("function handle"));
+    }
+
+    #[test]
+    fn agent_emits_signature_on_indented_continuation_line() {
+        let func = entry_with_sig(
+            OutlineKind::Function,
+            "validateToken",
+            24,
+            42,
+            "function validateToken(token: string): Claims | null",
+        );
+        let out = agent(
+            &[func],
+            AgentHeader {
+                path: "src/auth.ts",
+                lines: 100,
+                tokens: 600,
+            },
+        );
+        assert!(out.contains("function validateToken(token: string): Claims | null"));
+    }
+
+    #[test]
+    fn agent_indents_children_two_spaces_per_depth() {
+        let mut parent = entry(OutlineKind::Class, "Mgr", 1, 50);
+        parent
+            .children
+            .push(entry(OutlineKind::Function, "a", 5, 10));
+        parent
+            .children
+            .push(entry(OutlineKind::Function, "b", 11, 20));
+        let out = agent(
+            &[parent],
+            AgentHeader {
+                path: "x.rs",
+                lines: 50,
+                tokens: 200,
+            },
+        );
+        // Children rendered with two-space indent prefix.
+        assert!(out.lines().any(|l| l.starts_with("  [") && l.contains("function a")));
+        assert!(out.lines().any(|l| l.starts_with("  [") && l.contains("function b")));
+    }
+
+    #[test]
+    fn agent_handles_empty_outline_with_no_symbols_marker() {
+        let out = agent(
+            &[],
+            AgentHeader {
+                path: "empty.rs",
+                lines: 0,
+                tokens: 0,
+            },
+        );
+        assert!(out.contains("(no symbols)"));
+        // No footer hint when there are no symbols to drill into.
+        assert!(!out.contains("> Next:"));
+    }
+
+    #[test]
+    fn parse_import_source_extracts_quoted_module() {
+        assert_eq!(
+            parse_import_source("import x from 'express';"),
+            Some("express".into())
+        );
+        assert_eq!(
+            parse_import_source("const a = require(\"react\");"),
+            Some("react".into())
+        );
+    }
+
+    #[test]
+    fn parse_import_source_handles_python_from_and_import() {
+        assert_eq!(
+            parse_import_source("from collections import OrderedDict"),
+            Some("collections".into())
+        );
+        assert_eq!(
+            parse_import_source("import os"),
+            Some("os".into())
+        );
+    }
+
+    #[test]
+    fn parse_import_source_groups_rust_use_by_crate_root() {
+        assert_eq!(
+            parse_import_source("use anyhow::Result;"),
+            Some("anyhow".into())
+        );
+        assert_eq!(
+            parse_import_source("use std::collections::HashMap;"),
+            Some("std".into())
+        );
     }
 
     #[test]

--- a/crates/fff-cli/src/commands/outline_format.rs
+++ b/crates/fff-cli/src/commands/outline_format.rs
@@ -72,12 +72,7 @@ fn range_token(e: &OutlineEntry) -> String {
     format!("[{}-{}]", e.start_line, e.end_line)
 }
 
-fn push_agent_entry(
-    out: &mut String,
-    e: &OutlineEntry,
-    depth: usize,
-    range_width: usize,
-) {
+fn push_agent_entry(out: &mut String, e: &OutlineEntry, depth: usize, range_width: usize) {
     let indent = "  ".repeat(depth);
     let range = range_token(e);
     let visible = indent.len() + range.len();
@@ -109,11 +104,7 @@ fn push_agent_entry(
 
 /// Bundle leading consecutive imports into a single line: `[A-B] imports: a, b(2), c`.
 /// Returns the number of entries consumed.
-fn render_imports_bundle(
-    entries: &[OutlineEntry],
-    out: &mut String,
-    range_width: usize,
-) -> usize {
+fn render_imports_bundle(entries: &[OutlineEntry], out: &mut String, range_width: usize) -> usize {
     let count = entries
         .iter()
         .take_while(|e| matches!(e.kind, OutlineKind::Import))
@@ -187,10 +178,7 @@ fn parse_import_source(sig: &str) -> Option<String> {
 
     // Rust `use a::b::c;` — group by crate root.
     if let Some(rest) = s.strip_prefix("use ") {
-        let head = rest
-            .split(['{', ';', ' '])
-            .next()
-            .unwrap_or(rest);
+        let head = rest.split(['{', ';', ' ']).next().unwrap_or(rest);
         let root = head.split("::").next().unwrap_or(head);
         if !root.is_empty() {
             return Some(root.to_string());
@@ -344,7 +332,9 @@ fn kind_label(k: OutlineKind) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{agent, kind_label, markdown, parse_import_source, structured, tabular, AgentHeader};
+    use super::{
+        agent, kind_label, markdown, parse_import_source, structured, tabular, AgentHeader,
+    };
     use fff_symbol::types::{OutlineEntry, OutlineKind};
 
     fn entry(kind: OutlineKind, name: &str, start: u32, end: u32) -> OutlineEntry {
@@ -560,8 +550,12 @@ mod tests {
             },
         );
         // Children rendered with two-space indent prefix.
-        assert!(out.lines().any(|l| l.starts_with("  [") && l.contains("function a")));
-        assert!(out.lines().any(|l| l.starts_with("  [") && l.contains("function b")));
+        assert!(out
+            .lines()
+            .any(|l| l.starts_with("  [") && l.contains("function a")));
+        assert!(out
+            .lines()
+            .any(|l| l.starts_with("  [") && l.contains("function b")));
     }
 
     #[test]
@@ -597,10 +591,7 @@ mod tests {
             parse_import_source("from collections import OrderedDict"),
             Some("collections".into())
         );
-        assert_eq!(
-            parse_import_source("import os"),
-            Some("os".into())
-        );
+        assert_eq!(parse_import_source("import os"), Some("os".into()));
     }
 
     #[test]

--- a/crates/fff-cli/src/commands/read.rs
+++ b/crates/fff-cli/src/commands/read.rs
@@ -14,6 +14,7 @@ use fff_symbol::lang::detect_file_type;
 use fff_symbol::types::{FileType, OutlineEntry};
 
 use crate::cli::OutputFormat;
+use crate::commands::outline as outline_cmd;
 
 #[derive(Debug, Parser)]
 pub struct Args {
@@ -36,8 +37,8 @@ pub struct Args {
     #[arg(long, default_value_t = false, conflicts_with = "full")]
     pub section: bool,
 
-    /// Force whole-file mode even if `path:line` was given. Default if no
-    /// flag is set, but lets you pin behaviour explicitly.
+    /// Force whole-file mode and return raw contents. Without this flag the
+    /// scry default is the agent-style outline.
     #[arg(long, default_value_t = false)]
     pub full: bool,
 }
@@ -74,14 +75,37 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
         root.join(path_part)
     };
 
-    if args.section {
+    // Routing:
+    //   --section or `path:N`  → structural section read.
+    //   --full                  → whole-file body (legacy default).
+    //   no flags, no `:N`       → outline (B0 default for the scry layer).
+    if args.section || (line.is_some() && !args.full) {
         let line =
             line.ok_or_else(|| anyhow!("--section requires the target to be in `path:line` form"))?;
         let payload = read_section(&path, line, level, budget)?;
         return super::emit(format, &payload, section_text);
     }
 
-    // --full or default: whole-file read via the engine.
+    if !args.full {
+        // Outline default (only for code files; non-code falls through to
+        // full-body read so things like Markdown / JSON still emit content).
+        if matches!(detect_file_type(&path), FileType::Code(_)) {
+            let body = outline_cmd::render_agent(&path, path_part)?;
+            let kept_bytes = body.len();
+            let payload = ReadOutput {
+                path: path.to_string_lossy().to_string(),
+                mode: "outline",
+                body,
+                kept_bytes,
+                footer_bytes: 0,
+                line: None,
+                section: None,
+            };
+            return super::emit(format, &payload, |p| p.body.clone());
+        }
+    }
+
+    // --full or non-code target: whole-file read via the engine.
     let cfg = EngineConfig {
         filter_level: level,
         total_token_budget: budget,

--- a/crates/fff-cli/tests/cli_read_outline_default.rs
+++ b/crates/fff-cli/tests/cli_read_outline_default.rs
@@ -50,14 +50,24 @@ fn read_with_no_flags_emits_agent_outline_for_code_files() {
         .args(["read", "sample.rs"])
         .output()
         .expect("run scry read");
-    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let stdout = String::from_utf8(out.stdout).expect("utf8");
 
     // Header line: `# <path> (<lines> lines, ~<tokens> tokens) [outline]`.
-    assert!(stdout.starts_with("# sample.rs ("), "missing header line:\n{stdout}");
+    assert!(
+        stdout.starts_with("# sample.rs ("),
+        "missing header line:\n{stdout}"
+    );
     assert!(stdout.contains("[outline]"), "missing [outline] tag");
     // Bundled imports row.
-    assert!(stdout.contains("imports: std, anyhow"), "missing bundled imports:\n{stdout}");
+    assert!(
+        stdout.contains("imports: std, anyhow"),
+        "missing bundled imports:\n{stdout}"
+    );
     // Definitions present.
     assert!(stdout.contains("struct Foo"));
     assert!(stdout.contains("function entrypoint"));
@@ -77,7 +87,11 @@ fn read_with_full_flag_returns_raw_body() {
         .args(["read", "sample.rs", "--full"])
         .output()
         .expect("run scry read --full");
-    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let stdout = String::from_utf8(out.stdout).expect("utf8");
 
     // Raw body must include source lines.
@@ -98,12 +112,19 @@ fn read_with_line_suffix_drills_into_section() {
         .args(["read", "sample.rs:18"])
         .output()
         .expect("run scry read sample.rs:18");
-    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let stdout = String::from_utf8(out.stdout).expect("utf8");
 
     // Section banner is emitted; the body of the function we land on is
     // included; only the `entrypoint` body is rendered.
-    assert!(stdout.starts_with("// "), "expected section banner:\n{stdout}");
+    assert!(
+        stdout.starts_with("// "),
+        "expected section banner:\n{stdout}"
+    );
     assert!(stdout.contains("pub fn entrypoint() -> Result<()>"));
     assert!(stdout.contains("Foo::new()"));
     assert!(!stdout.contains("pub struct Foo"));
@@ -119,10 +140,17 @@ fn outline_default_style_is_agent() {
         .args(["outline", "sample.rs"])
         .output()
         .expect("run scry outline");
-    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let stdout = String::from_utf8(out.stdout).expect("utf8");
 
-    assert!(stdout.starts_with("# sample.rs ("), "default outline style should be agent:\n{stdout}");
+    assert!(
+        stdout.starts_with("# sample.rs ("),
+        "default outline style should be agent:\n{stdout}"
+    );
     assert!(stdout.contains("> Next: drill into a symbol"));
 }
 

--- a/crates/fff-cli/tests/cli_read_outline_default.rs
+++ b/crates/fff-cli/tests/cli_read_outline_default.rs
@@ -1,0 +1,153 @@
+//! End-to-end tests for the B0 default-routing of `scry read`:
+//! a no-flag invocation returns the agent-style outline, not the full body.
+
+use std::process::Command;
+
+use tempfile::TempDir;
+
+const SAMPLE: &str = "\
+use std::collections::HashMap;
+use anyhow::Result;
+
+pub struct Foo {
+    pub bar: u32,
+}
+
+impl Foo {
+    pub fn new() -> Self {
+        Self { bar: 0 }
+    }
+
+    pub fn bar(&self) -> u32 {
+        self.bar
+    }
+}
+
+pub fn entrypoint() -> Result<()> {
+    let _ = Foo::new();
+    Ok(())
+}
+";
+
+fn binary() -> std::path::PathBuf {
+    let exe = env!("CARGO_BIN_EXE_scry");
+    std::path::PathBuf::from(exe)
+}
+
+fn write_sample(dir: &std::path::Path) -> std::path::PathBuf {
+    let path = dir.join("sample.rs");
+    std::fs::write(&path, SAMPLE).expect("write sample");
+    path
+}
+
+#[test]
+fn read_with_no_flags_emits_agent_outline_for_code_files() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _ = write_sample(tmp.path());
+
+    let out = Command::new(binary())
+        .args(["--root", tmp.path().to_str().unwrap()])
+        .args(["read", "sample.rs"])
+        .output()
+        .expect("run scry read");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+
+    // Header line: `# <path> (<lines> lines, ~<tokens> tokens) [outline]`.
+    assert!(stdout.starts_with("# sample.rs ("), "missing header line:\n{stdout}");
+    assert!(stdout.contains("[outline]"), "missing [outline] tag");
+    // Bundled imports row.
+    assert!(stdout.contains("imports: std, anyhow"), "missing bundled imports:\n{stdout}");
+    // Definitions present.
+    assert!(stdout.contains("struct Foo"));
+    assert!(stdout.contains("function entrypoint"));
+    // Footer hint.
+    assert!(stdout.contains("> Next: drill into a symbol"));
+    // Should NOT include raw body (e.g. the function bodies).
+    assert!(!stdout.contains("self.bar = 0"));
+}
+
+#[test]
+fn read_with_full_flag_returns_raw_body() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _ = write_sample(tmp.path());
+
+    let out = Command::new(binary())
+        .args(["--root", tmp.path().to_str().unwrap()])
+        .args(["read", "sample.rs", "--full"])
+        .output()
+        .expect("run scry read --full");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+
+    // Raw body must include source lines.
+    assert!(stdout.contains("pub struct Foo {"));
+    assert!(stdout.contains("pub fn entrypoint() -> Result<()>"));
+    // No outline header in `--full` mode.
+    assert!(!stdout.starts_with("# "));
+    assert!(!stdout.contains("[outline]"));
+}
+
+#[test]
+fn read_with_line_suffix_drills_into_section() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _ = write_sample(tmp.path());
+
+    let out = Command::new(binary())
+        .args(["--root", tmp.path().to_str().unwrap()])
+        .args(["read", "sample.rs:18"])
+        .output()
+        .expect("run scry read sample.rs:18");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+
+    // Section banner is emitted; the body of the function we land on is
+    // included; only the `entrypoint` body is rendered.
+    assert!(stdout.starts_with("// "), "expected section banner:\n{stdout}");
+    assert!(stdout.contains("pub fn entrypoint() -> Result<()>"));
+    assert!(stdout.contains("Foo::new()"));
+    assert!(!stdout.contains("pub struct Foo"));
+}
+
+#[test]
+fn outline_default_style_is_agent() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _ = write_sample(tmp.path());
+
+    let out = Command::new(binary())
+        .args(["--root", tmp.path().to_str().unwrap()])
+        .args(["outline", "sample.rs"])
+        .output()
+        .expect("run scry outline");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+
+    assert!(stdout.starts_with("# sample.rs ("), "default outline style should be agent:\n{stdout}");
+    assert!(stdout.contains("> Next: drill into a symbol"));
+}
+
+#[test]
+fn outline_legacy_styles_still_work() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _ = write_sample(tmp.path());
+
+    for style in ["markdown", "structured", "tabular"] {
+        let out = Command::new(binary())
+            .args(["--root", tmp.path().to_str().unwrap()])
+            .args(["outline", "sample.rs", "--style", style])
+            .output()
+            .unwrap_or_else(|e| panic!("run scry outline --style {style}: {e}"));
+        assert!(
+            out.status.success(),
+            "style {style} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let stdout = String::from_utf8(out.stdout).expect("utf8");
+        assert!(!stdout.is_empty(), "style {style} produced empty output");
+        // Agent-only header must NOT appear under legacy styles.
+        assert!(
+            !stdout.starts_with("# sample.rs ("),
+            "style {style} unexpectedly emitted agent header"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

PR 1/19 of the scry implementation roadmap (Stream B · B0).

Brings the agent-friendly outline shape to `scry read` and `scry outline`:

- **`scry read <path>` (no flags) → outline** by default (was: full file body).
- `scry read <path>:N` → drills into the structural section at line N.
- `scry read <path> --full` → raw whole-file body (legacy behaviour, still available).
- **`scry outline` gains `--style agent`** as the new default.

Legacy `--style markdown / structured / tabular` still work — only the default changed.

Boundaries respected: only `crates/fff-cli` (the scry layer) is touched. `fff-core`, `fff-grep`, `fff-query-parser`, `fff-mcp` 3 original tools, `fff-nvim` public API, `fff-c` default ABI, and SDKs are untouched.

## Review & Testing Checklist for Human

- [ ] `scry read <some-existing-file>` (no flags) emits the agent outline rather than raw body.
- [ ] `scry read <file>:<line>` drills into the smallest structural section that contains `<line>`.
- [ ] `scry read <file> --full` returns the raw body byte-for-byte (no header).
- [ ] `scry outline <file> --style markdown / structured / tabular` still produce sensible output.
- [ ] Skim agent output of a TS file with imports — imports collapse onto one row, named-source dedup works.

End-to-end smoke test:
```
cargo test -p fff-cli                                     # 79 unit + 5 integration, all green
cargo clippy -p fff-cli --no-deps -- -D warnings          # lint clean
./target/debug/scry read crates/fff-cli/src/commands/outline.rs   # outline default
./target/debug/scry read crates/fff-cli/src/commands/outline.rs --full
./target/debug/scry read crates/fff-cli/src/commands/outline.rs:90
```

### Notes

- 5 new integration tests in `crates/fff-cli/tests/cli_read_outline_default.rs` lock the routing matrix end-to-end.
- Adds a `pub fn render_agent` library-style helper in `commands::outline` so future PRs (B1 `--expand`, B5 `flow`, B6 `impact`) can reuse the same renderer.
- Imports parsing is heuristic (quoted module name → Python `from X` → Rust `use X::...` crate root). Falls back to `entry.name` when nothing parses.
- Non-code targets (Markdown, JSON, etc.) keep falling through to `--full`-style raw body — outline mode is code-only, since tree-sitter can't parse them.

Part 1 of `scry-plan.md` v3 — 19 PRs across 3 streams (B sub-commands, A token-saver, C migration). Next: **B1 — `scry symbol --expand` + `--did-you-mean`**.