### PR TITLE
feat(scry): scry refs <symbol> — defs + single-hop usages (B8)

### DIFF
--- a/crates/fff-cli/assets/AGENT_GUIDE.md
+++ b/crates/fff-cli/assets/AGENT_GUIDE.md
@@ -20,7 +20,7 @@ All sub-commands accept these.
 
 ## Pagination
 
-Listing sub-commands (`find`, `symbol`, `callers`, `callees`,
+Listing sub-commands (`find`, `symbol`, `callers`, `callees`, `refs`,
 `siblings`) take:
 
 * `--limit <N>` — max items in this page (defaults differ per command;
@@ -101,6 +101,15 @@ Identifiers referenced inside the body of `<name>`, then resolved
 back to definitions via the symbol index. Hits with the same
 `(name, path, line)` triple are de-duplicated even when they came
 from multiple definition bodies of `<name>`.
+
+### `refs <name>`
+Definitions plus single-hop usages of `<name>` in one response.
+Definitions come from the symbol index (full list, no pagination);
+usages reuse the `callers --hops 1` text-confirm pass and are paged
+via `--limit` / `--offset`. JSON shape:
+`{ name, definitions, usages, total_usages, offset, has_more }`.
+Each usage carries `enclosing` when it can be resolved via the
+outline cache.
 
 ### `siblings <name>`
 Other symbols defined at the same scope as `<name>` — peer methods of

--- a/crates/fff-cli/src/cli.rs
+++ b/crates/fff-cli/src/cli.rs
@@ -60,6 +60,9 @@ pub enum Command {
     /// List callees referenced inside a symbol body (NEW).
     Callees(commands::callees::Args),
 
+    /// List definitions and usages of a symbol in one shot (NEW).
+    Refs(commands::refs::Args),
+
     /// List sibling symbols (peers in the same parent scope).
     Siblings(commands::siblings::Args),
 
@@ -101,6 +104,7 @@ impl Cli {
             Command::Symbol(a) => commands::symbol::run(a, &root, self.format),
             Command::Callers(a) => commands::callers::run(a, &root, self.format),
             Command::Callees(a) => commands::callees::run(a, &root, self.format),
+            Command::Refs(a) => commands::refs::run(a, &root, self.format),
             Command::Siblings(a) => commands::siblings::run(a, &root, self.format),
             Command::Deps(a) => commands::deps::run(a, &root, self.format),
             Command::Dispatch(a) => commands::dispatch::run(a, &root, self.format),

--- a/crates/fff-cli/src/commands/mod.rs
+++ b/crates/fff-cli/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod outline_format;
 pub mod overview;
 pub(crate) mod pagination;
 pub mod read;
+pub mod refs;
 pub mod siblings;
 pub mod symbol;
 

--- a/crates/fff-cli/src/commands/refs.rs
+++ b/crates/fff-cli/src/commands/refs.rs
@@ -1,0 +1,307 @@
+// `scry refs <name>` — definitions + single-hop usages in one shot.
+// Definitions come from the symbol index (full list, no pagination).
+// Usages reuse the `callers --hops 1` text-confirm pass; pagination
+// applies to usages only so the defs block is always complete.
+
+use std::path::Path;
+use std::time::SystemTime;
+
+use anyhow::Result;
+use clap::Parser;
+use serde::Serialize;
+
+use fff_engine::{Engine, PreFilterStack};
+use fff_symbol::lang::detect_file_type;
+use fff_symbol::types::FileType;
+
+use crate::cli::OutputFormat;
+use crate::commands::callers_bfs::{enclosing_symbol, CandidateFile};
+use crate::commands::pagination::{footer, Page};
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// Symbol name to find references (definitions + usages) for.
+    pub name: String,
+
+    /// Maximum usages returned in this page. Definitions ignore this.
+    #[arg(long, default_value_t = 100)]
+    pub limit: usize,
+
+    /// Skip this many usages before starting the page. Definitions ignore this.
+    #[arg(long, default_value_t = 0)]
+    pub offset: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct RefDefinition {
+    path: String,
+    line: u32,
+    end_line: u32,
+    kind: String,
+    weight: u16,
+}
+
+#[derive(Debug, Serialize)]
+struct RefUsage {
+    path: String,
+    line: u32,
+    text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enclosing: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RefsOutput {
+    name: String,
+    definitions: Vec<RefDefinition>,
+    usages: Vec<RefUsage>,
+    total_usages: usize,
+    offset: usize,
+    has_more: bool,
+}
+
+pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
+    let engine = Engine::default();
+    engine.index(root);
+
+    let definitions = collect_definitions(&engine, &args.name);
+    let candidates = build_candidates(root);
+    let usages = collect_usages(&engine, &args.name, &candidates);
+
+    let page = Page::paginate(usages, args.offset, args.limit);
+    let payload = RefsOutput {
+        name: args.name.clone(),
+        definitions,
+        total_usages: page.total,
+        offset: page.offset,
+        has_more: page.has_more,
+        usages: page.items,
+    };
+    super::emit(format, &payload, render_text)
+}
+
+fn collect_definitions(engine: &Engine, name: &str) -> Vec<RefDefinition> {
+    engine
+        .handles
+        .symbols
+        .lookup_exact(name)
+        .into_iter()
+        .map(|loc| RefDefinition {
+            path: loc.path.to_string_lossy().to_string(),
+            line: loc.line,
+            end_line: loc.end_line,
+            kind: loc.kind,
+            weight: loc.weight,
+        })
+        .collect()
+}
+
+fn build_candidates(root: &Path) -> Vec<CandidateFile> {
+    super::walk_files(root)
+        .into_iter()
+        .filter_map(|path| {
+            let meta = std::fs::metadata(&path).ok()?;
+            let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+            let content = std::fs::read_to_string(&path).ok()?;
+            let lang = match detect_file_type(&path) {
+                FileType::Code(l) => Some(l),
+                _ => None,
+            };
+            Some(CandidateFile {
+                path,
+                mtime,
+                content,
+                lang,
+            })
+        })
+        .collect()
+}
+
+fn collect_usages(engine: &Engine, name: &str, candidates: &[CandidateFile]) -> Vec<RefUsage> {
+    let definitions = engine.handles.symbols.lookup_exact(name);
+    let definition_paths: Vec<String> = definitions
+        .iter()
+        .map(|d| d.path.to_string_lossy().to_string())
+        .collect();
+
+    let stack = PreFilterStack::new(engine.handles.bloom.clone());
+    let confirm_input: Vec<(std::path::PathBuf, SystemTime, String)> = candidates
+        .iter()
+        .map(|c| (c.path.clone(), c.mtime, c.content.clone()))
+        .collect();
+    let survivors = stack.confirm_symbol(&confirm_input, name);
+    let survivor_set: std::collections::HashSet<&std::path::Path> =
+        survivors.iter().map(|s| s.path.as_path()).collect();
+
+    let mut usages: Vec<RefUsage> = Vec::new();
+    for cf in candidates {
+        if !survivor_set.contains(cf.path.as_path()) {
+            continue;
+        }
+        let path_str = cf.path.to_string_lossy().to_string();
+        let in_defn_file = definition_paths.contains(&path_str);
+        let definition_lines: Vec<u32> = if in_defn_file {
+            definitions
+                .iter()
+                .filter(|d| d.path.to_string_lossy() == path_str)
+                .map(|d| d.line)
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        let outline = if let Some(lang) = cf.lang {
+            engine
+                .handles
+                .outlines
+                .get_or_compute(&cf.path, cf.mtime, &cf.content, lang)
+        } else {
+            Vec::new()
+        };
+
+        for (lineno, line) in cf.content.lines().enumerate() {
+            let lineno = (lineno + 1) as u32;
+            if !line.contains(name) {
+                continue;
+            }
+            if definition_lines.contains(&lineno) {
+                continue;
+            }
+            usages.push(RefUsage {
+                path: path_str.clone(),
+                line: lineno,
+                text: line.to_string(),
+                enclosing: enclosing_symbol(&outline, lineno),
+            });
+        }
+    }
+    usages
+}
+
+fn render_text(p: &RefsOutput) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("Definitions ({}):\n", p.definitions.len()));
+    if p.definitions.is_empty() {
+        out.push_str("  [none]\n");
+    } else {
+        for d in &p.definitions {
+            out.push_str(&format!(
+                "  {}:{} ({}, w={})\n",
+                d.path, d.line, d.kind, d.weight
+            ));
+        }
+    }
+
+    out.push_str(&format!("\nUsages ({}):\n", p.total_usages));
+    if p.total_usages == 0 {
+        out.push_str("  [none]\n");
+    } else {
+        for u in &p.usages {
+            let encl = u.enclosing.as_deref().unwrap_or("?");
+            out.push_str(&format!(
+                "  {}:{} (in {}): {}\n",
+                u.path, u.line, encl, u.text
+            ));
+        }
+        out.push_str(&footer(
+            p.total_usages,
+            p.offset,
+            p.usages.len(),
+            p.has_more,
+        ));
+    }
+
+    if p.definitions.is_empty() && p.total_usages == 0 {
+        out.push_str("\n[no references found]\n");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn dummy_payload() -> RefsOutput {
+        RefsOutput {
+            name: "foo".into(),
+            definitions: vec![RefDefinition {
+                path: "src/a.rs".into(),
+                line: 10,
+                end_line: 20,
+                kind: "function".into(),
+                weight: 5,
+            }],
+            usages: vec![RefUsage {
+                path: "src/b.rs".into(),
+                line: 30,
+                text: "    foo();".into(),
+                enclosing: Some("bar".into()),
+            }],
+            total_usages: 1,
+            offset: 0,
+            has_more: false,
+        }
+    }
+
+    #[test]
+    fn json_shape_includes_required_fields() {
+        let p = dummy_payload();
+        let v: Value = serde_json::to_value(&p).unwrap();
+        for k in [
+            "name",
+            "definitions",
+            "usages",
+            "total_usages",
+            "offset",
+            "has_more",
+        ] {
+            assert!(v.get(k).is_some(), "missing field {k}");
+        }
+        assert_eq!(v["definitions"][0]["kind"], "function");
+        assert_eq!(v["usages"][0]["enclosing"], "bar");
+    }
+
+    #[test]
+    fn text_render_groups_defs_then_usages() {
+        let s = render_text(&dummy_payload());
+        let defs_idx = s.find("Definitions").unwrap();
+        let usages_idx = s.find("Usages").unwrap();
+        assert!(defs_idx < usages_idx);
+        assert!(s.contains("src/a.rs:10"));
+        assert!(s.contains("src/b.rs:30 (in bar)"));
+    }
+
+    #[test]
+    fn text_render_zero_refs_emits_none_marker() {
+        let p = RefsOutput {
+            name: "missing".into(),
+            definitions: Vec::new(),
+            usages: Vec::new(),
+            total_usages: 0,
+            offset: 0,
+            has_more: false,
+        };
+        let s = render_text(&p);
+        assert!(s.contains("[no references found]"));
+    }
+
+    #[test]
+    fn json_omits_enclosing_when_none() {
+        let p = RefsOutput {
+            name: "x".into(),
+            definitions: Vec::new(),
+            usages: vec![RefUsage {
+                path: "p".into(),
+                line: 1,
+                text: "x".into(),
+                enclosing: None,
+            }],
+            total_usages: 1,
+            offset: 0,
+            has_more: false,
+        };
+        let v: Value = serde_json::to_value(&p).unwrap();
+        assert!(v["usages"][0].get("enclosing").is_none());
+    }
+}


### PR DESCRIPTION
## Summary

New `scry refs <name>` sub-command — definitions + single-hop usages of a symbol in one shot.

- **Definitions** come from `Engine.handles.symbols.lookup_exact(name)` and are returned in full (no pagination, so the answer to "where is this defined" never falls off page 1).
- **Usages** reuse the `callers --hops 1` text-confirm pass (bloom-narrowed → literal scan → drop definition lines). Each usage carries `enclosing` resolved via the existing outline cache + `enclosing_symbol` helper. Pagination via `--limit` / `--offset` applies only to usages.
- **JSON shape**: `{ name, definitions: [...], usages: [...], total_usages, offset, has_more }`. Matches the plan's B8 spec verbatim.
- **Text rendering**: groups `Definitions (N):` then `Usages (N):` with the standard pagination footer underneath usages and a `[no references found]` marker only when both are empty.

This is opt-in surface — no existing command's defaults shift. CLI wiring is the only touch in `cli.rs` / `mod.rs`. MCP/Lua/C exposure is intentionally deferred to B7 per the plan.

### Files changed
- `crates/fff-cli/src/commands/refs.rs` — new (~290 lines, 4 unit tests)
- `crates/fff-cli/src/cli.rs` — register `Refs` sub-command + dispatch
- `crates/fff-cli/src/commands/mod.rs` — `pub mod refs;`
- `crates/fff-cli/assets/AGENT_GUIDE.md` — document the new sub-command

### Verified locally
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --features zlob -- -D warnings`
- `cargo test --workspace --features zlob --exclude fff-nvim` — all green (4 new tests + the existing 100+ tests untouched)
- Smoke test against this repo: `scry refs lookup_exact` (and `--format json`) emits the expected envelope; `scry refs nonexistent_xyz` shows the empty marker; `--offset` paginates usages while leaving the definitions block intact.

## Review & Testing Checklist for Human

- [ ] Run `scry refs <symbol>` (text + `--format json`) on a symbol you know has multiple definitions/usages — confirm the JSON keys match `{ name, definitions, usages, total_usages, offset, has_more }` and `enclosing` is populated where the outline knows the parent.
- [ ] Verify `--limit` / `--offset` paginates **usages only** (definitions stay full across pages).
- [ ] Spot-check a non-existent symbol: `scry refs zzz_missing` should print `[no references found]`.

### Notes
- B8 reuses single-hop callers logic verbatim; if `callers` ever gains/changes filters (case-sensitivity, comment exclusion, etc.) we may want to factor a shared helper. Out of scope for this PR.
- The pagination footer for `--offset` past total emits `[101-100 of 25]` — same shape as every other paginated sub-command (see `pagination::tests::footer_offset_at_end_shows_empty_range`), kept consistent on purpose.