### PR TITLE
feat(scry): scry callees --depth N — BFS forward graph (B9)

### DIFF
--- a/crates/fff-cli/assets/AGENT_GUIDE.md
+++ b/crates/fff-cli/assets/AGENT_GUIDE.md
@@ -102,6 +102,14 @@ back to definitions via the symbol index. Hits with the same
 `(name, path, line)` triple are de-duplicated even when they came
 from multiple definition bodies of `<name>`.
 
+* `--depth N` — walk the callee graph N hops (default 1, max 5).
+  When `N > 1` each hit carries `depth` and `from` (the enclosing
+  symbol whose body produced it). Default `--depth 1` keeps the
+  output byte-identical to before.
+* `--hub-guard N` — stop propagating from any single name that
+  produces more than N hits in one hop (default 50). The hits still
+  surface; only further expansion from that name is skipped.
+
 ### `refs <name>`
 Definitions plus single-hop usages of `<name>` in one response.
 Definitions come from the symbol index (full list, no pagination);

--- a/crates/fff-cli/src/commands/callees.rs
+++ b/crates/fff-cli/src/commands/callees.rs
@@ -1,5 +1,6 @@
 //! `scry callees <symbol>` — given a symbol's body, list which other indexed
-//! symbols are referenced inside it. Useful for impact analysis.
+//! symbols are referenced inside it. With `--depth > 1` the search becomes a
+//! BFS over the callee graph (mirror of `callers --hops N`).
 
 use std::path::Path;
 
@@ -12,6 +13,7 @@ use fff_symbol::lang::detect_file_type;
 use fff_symbol::types::FileType;
 
 use crate::cli::OutputFormat;
+use crate::commands::callees_bfs::{run_bfs, BfsConfig, CalleeHit as BfsCalleeHit};
 use crate::commands::callees_resolve::collect_callees;
 use crate::commands::dedup::dedup_by;
 use crate::commands::pagination::{footer, Page};
@@ -28,6 +30,15 @@ pub struct Args {
     /// Skip this many callees before starting the page.
     #[arg(long, default_value_t = 0)]
     pub offset: usize,
+
+    /// How far to walk the callee graph. 1 = direct callees only. Capped at 5.
+    #[arg(long, default_value_t = 1)]
+    pub depth: u32,
+
+    /// Skip propagation when a single name produces more than this many hits
+    /// in one hop. Prevents popular helpers from blowing up the BFS.
+    #[arg(long, default_value_t = 50)]
+    pub hub_guard: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -35,11 +46,19 @@ struct CalleeHit {
     name: String,
     path: String,
     line: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    depth: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    from: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
 struct CalleesOutput {
     name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    depth: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hub_guard: Option<usize>,
     hits: Vec<CalleeHit>,
     total: usize,
     offset: usize,
@@ -50,9 +69,50 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
     let engine = Engine::default();
     engine.index(root);
 
-    let definitions = engine.handles.symbols.lookup_exact(&args.name);
-    let mut hits: Vec<CalleeHit> = Vec::new();
+    let hits = if args.depth <= 1 {
+        single_hop(&engine, &args.name)
+    } else {
+        let bfs_hits = run_bfs(
+            &engine,
+            &args.name,
+            BfsConfig {
+                max_hops: args.depth,
+                hub_guard: args.hub_guard,
+            },
+        );
+        bfs_hits
+            .into_iter()
+            .map(|h: BfsCalleeHit| CalleeHit {
+                name: h.name,
+                path: h.path,
+                line: h.line,
+                depth: Some(h.depth),
+                from: Some(h.from),
+            })
+            .collect()
+    };
 
+    // Multiple paths to the same target collapse into one hit. Depth-aware
+    // runs key on `(name, path, line, depth)` so the same target reached via
+    // different hops keeps its layered context.
+    let hits = dedup_by(hits, |h| (h.name.clone(), h.path.clone(), h.line, h.depth));
+    let page = Page::paginate(hits, args.offset, args.limit);
+    let multi_hop = args.depth > 1;
+    let payload = CalleesOutput {
+        name: args.name,
+        depth: multi_hop.then(|| args.depth.clamp(1, 5)),
+        hub_guard: multi_hop.then_some(args.hub_guard),
+        total: page.total,
+        offset: page.offset,
+        has_more: page.has_more,
+        hits: page.items,
+    };
+    super::emit(format, &payload, render_text)
+}
+
+fn single_hop(engine: &Engine, name: &str) -> Vec<CalleeHit> {
+    let definitions = engine.handles.symbols.lookup_exact(name);
+    let mut hits: Vec<CalleeHit> = Vec::new();
     for def in &definitions {
         let lang = match detect_file_type(&def.path) {
             FileType::Code(l) => l,
@@ -65,7 +125,7 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
             continue;
         };
         for ident in names {
-            if ident == args.name {
+            if ident == name {
                 continue;
             }
             for loc in engine.handles.symbols.lookup_exact(&ident) {
@@ -73,33 +133,36 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
                     name: ident.clone(),
                     path: loc.path.to_string_lossy().to_string(),
                     line: loc.line,
+                    depth: None,
+                    from: None,
                 });
             }
         }
     }
+    hits
+}
 
-    // Multiple definition sites of the same target symbol can produce the same
-    // (name, path, line) triple from different bodies; collapse them so each
-    // unique callee is reported once.
-    let hits = dedup_by(hits, |h| (h.name.clone(), h.path.clone(), h.line));
-    let page = Page::paginate(hits, args.offset, args.limit);
-    let payload = CalleesOutput {
-        name: args.name,
-        total: page.total,
-        offset: page.offset,
-        has_more: page.has_more,
-        hits: page.items,
-    };
-    super::emit(format, &payload, |p| {
-        let mut out = String::new();
+fn render_text(p: &CalleesOutput) -> String {
+    let mut out = String::new();
+    let multi_hop = p.depth.is_some();
+    if multi_hop {
+        for h in &p.hits {
+            let d = h.depth.unwrap_or(1);
+            let from = h.from.as_deref().unwrap_or("?");
+            out.push_str(&format!(
+                "[d{}] {} @ {}:{}  (called from {})\n",
+                d, h.name, h.path, h.line, from
+            ));
+        }
+    } else {
         for h in &p.hits {
             out.push_str(&format!("{} @ {}:{}\n", h.name, h.path, h.line));
         }
-        if p.total == 0 {
-            out.push_str("[no callees found]\n");
-        } else {
-            out.push_str(&footer(p.total, p.offset, p.hits.len(), p.has_more));
-        }
-        out
-    })
+    }
+    if p.total == 0 {
+        out.push_str("[no callees found]\n");
+    } else {
+        out.push_str(&footer(p.total, p.offset, p.hits.len(), p.has_more));
+    }
+    out
 }

--- a/crates/fff-cli/src/commands/callees_bfs.rs
+++ b/crates/fff-cli/src/commands/callees_bfs.rs
@@ -1,0 +1,283 @@
+// Forward-graph BFS for `scry callees --depth N`. Each hop:
+// 1. For every name in the current frontier, look up definitions and run
+//    `collect_callees` over each definition's body to get the set of called
+//    identifiers.
+// 2. Resolve each identifier back to all known definition sites; emit one
+//    hit per (caller, target_def) pair tagged with the current depth and the
+//    enclosing symbol that produced it (`from`).
+// 3. Add the called identifiers to the next frontier, modulo `hub_guard`:
+//    if a single name produces more than `hub_guard` callee hits at this
+//    hop, its propagation is skipped (but the hits still surface).
+//
+// Frontier is name-keyed and visited-tracked, so a symbol with many
+// definition sites is expanded once per hop.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::Serialize;
+
+use fff_engine::Engine;
+use fff_symbol::lang::detect_file_type;
+use fff_symbol::types::FileType;
+
+use crate::commands::callees_resolve::collect_callees;
+
+pub struct BfsConfig {
+    pub max_hops: u32,
+    pub hub_guard: usize,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct CalleeHit {
+    pub name: String,
+    pub path: String,
+    pub line: u32,
+    pub depth: u32,
+    pub from: String,
+}
+
+pub fn run_bfs(engine: &Engine, initial: &str, cfg: BfsConfig) -> Vec<CalleeHit> {
+    let mut visited: HashSet<String> = HashSet::new();
+    visited.insert(initial.to_string());
+    let mut frontier: Vec<String> = vec![initial.to_string()];
+    let mut all_hits: Vec<CalleeHit> = Vec::new();
+
+    let max_hops = cfg.max_hops.clamp(1, 5);
+
+    for depth in 1..=max_hops {
+        if frontier.is_empty() {
+            break;
+        }
+
+        let mut next_set: HashSet<String> = HashSet::new();
+        let mut hub_for_name: HashMap<String, usize> = HashMap::new();
+
+        for name in &frontier {
+            let mut hits_for_name = 0usize;
+            let mut idents_this_name: Vec<String> = Vec::new();
+
+            for def in engine.handles.symbols.lookup_exact(name) {
+                let lang = match detect_file_type(&def.path) {
+                    FileType::Code(l) => l,
+                    _ => continue,
+                };
+                let Ok(content) = std::fs::read_to_string(&def.path) else {
+                    continue;
+                };
+                let Some(idents) = collect_callees(&content, lang, def.line, def.end_line) else {
+                    continue;
+                };
+                for ident in &idents {
+                    if ident == name {
+                        continue;
+                    }
+                    let locs = engine.handles.symbols.lookup_exact(ident);
+                    if locs.is_empty() {
+                        continue;
+                    }
+                    idents_this_name.push(ident.clone());
+                    for loc in locs {
+                        all_hits.push(CalleeHit {
+                            name: ident.clone(),
+                            path: loc.path.to_string_lossy().to_string(),
+                            line: loc.line,
+                            depth,
+                            from: name.clone(),
+                        });
+                        hits_for_name += 1;
+                    }
+                }
+            }
+
+            hub_for_name.insert(name.clone(), hits_for_name);
+            if hits_for_name <= cfg.hub_guard {
+                for i in idents_this_name {
+                    next_set.insert(i);
+                }
+            }
+        }
+
+        next_set.retain(|n| !visited.contains(n));
+        for n in &next_set {
+            visited.insert(n.clone());
+        }
+        frontier = next_set.into_iter().collect();
+    }
+
+    all_hits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fff_engine::Engine;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write(dir: &std::path::Path, name: &str, body: &str) {
+        fs::write(dir.join(name), body).unwrap();
+    }
+
+    fn engine_for(root: &std::path::Path) -> Engine {
+        let e = Engine::default();
+        e.index(root);
+        e
+    }
+
+    #[test]
+    fn depth_one_returns_only_direct_callees() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+fn alpha() { beta(); }
+fn beta() { gamma(); }
+fn gamma() {}
+"#,
+        );
+        let e = engine_for(tmp.path());
+        let hits = run_bfs(
+            &e,
+            "alpha",
+            BfsConfig {
+                max_hops: 1,
+                hub_guard: 50,
+            },
+        );
+        let names: Vec<&str> = hits.iter().map(|h| h.name.as_str()).collect();
+        assert!(names.contains(&"beta"));
+        assert!(!names.contains(&"gamma"));
+        assert!(hits.iter().all(|h| h.depth == 1));
+        assert!(hits.iter().all(|h| h.from == "alpha"));
+    }
+
+    #[test]
+    fn depth_two_reaches_grandchildren() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+fn alpha() { beta(); }
+fn beta() { gamma(); }
+fn gamma() {}
+"#,
+        );
+        let e = engine_for(tmp.path());
+        let hits = run_bfs(
+            &e,
+            "alpha",
+            BfsConfig {
+                max_hops: 2,
+                hub_guard: 50,
+            },
+        );
+        let beta = hits
+            .iter()
+            .find(|h| h.name == "beta")
+            .expect("beta missing");
+        let gamma = hits
+            .iter()
+            .find(|h| h.name == "gamma")
+            .expect("gamma missing");
+        assert_eq!(beta.depth, 1);
+        assert_eq!(beta.from, "alpha");
+        assert_eq!(gamma.depth, 2);
+        assert_eq!(gamma.from, "beta");
+    }
+
+    #[test]
+    fn hub_guard_blocks_propagation_but_keeps_hits() {
+        let tmp = TempDir::new().unwrap();
+        // alpha calls hub once; hub calls a, b, c — three hits at hub. With
+        // hub_guard=2 the hub's body is still scanned and hits surface, but
+        // a/b/c don't enter the next frontier.
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+fn alpha() { hub(); }
+fn hub() { a(); b(); c(); }
+fn a() { d(); }
+fn b() {}
+fn c() {}
+fn d() {}
+"#,
+        );
+        let e = engine_for(tmp.path());
+        let hits = run_bfs(
+            &e,
+            "alpha",
+            BfsConfig {
+                max_hops: 3,
+                hub_guard: 2,
+            },
+        );
+        let names: HashSet<&str> = hits.iter().map(|h| h.name.as_str()).collect();
+        assert!(names.contains("hub"));
+        assert!(names.contains("a"));
+        assert!(names.contains("b"));
+        assert!(names.contains("c"));
+        // d is two hops past the hub-guarded frontier; without the guard it
+        // would have surfaced at depth 3.
+        assert!(!names.contains("d"));
+    }
+
+    #[test]
+    fn cycle_terminates_without_repeating_expansion() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+fn alpha() { beta(); }
+fn beta() { alpha(); }
+"#,
+        );
+        let e = engine_for(tmp.path());
+        let hits = run_bfs(
+            &e,
+            "alpha",
+            BfsConfig {
+                max_hops: 5,
+                hub_guard: 50,
+            },
+        );
+        // beta surfaces at depth 1 (alpha calls beta). Calling alpha back
+        // from beta is a legitimate hit at depth 2 — what `visited` prevents
+        // is re-expanding alpha into a third pass. Each (name, depth) appears
+        // at most once.
+        assert!(hits.iter().any(|h| h.name == "beta" && h.depth == 1));
+        let alpha_at_2: Vec<&CalleeHit> = hits
+            .iter()
+            .filter(|h| h.name == "alpha" && h.depth == 2)
+            .collect();
+        assert_eq!(alpha_at_2.len(), 1);
+        assert!(hits.iter().all(|h| h.depth <= 2));
+    }
+
+    #[test]
+    fn max_hops_clamps_to_five() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+fn alpha() {}
+"#,
+        );
+        let e = engine_for(tmp.path());
+        // No callees at any depth — BFS must terminate quickly even when the
+        // caller asks for 100 hops.
+        let hits = run_bfs(
+            &e,
+            "alpha",
+            BfsConfig {
+                max_hops: 100,
+                hub_guard: 50,
+            },
+        );
+        assert!(hits.is_empty());
+    }
+}

--- a/crates/fff-cli/src/commands/mod.rs
+++ b/crates/fff-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod callees;
+pub(crate) mod callees_bfs;
 pub(crate) mod callees_resolve;
 pub mod callers;
 pub(crate) mod callers_bfs;


### PR DESCRIPTION
## Summary

B9: `scry callees` now accepts `--depth N` (default 1, max 5) and `--hub-guard N` (default 50). When `N > 1` the command performs a breadth-first walk over the callee graph — the forward-direction mirror of `callers --hops N`.

- New `crates/fff-cli/src/commands/callees_bfs.rs` mirrors `callers_bfs.rs`: per-hop frontier of names, scan each definition body via `collect_callees`, resolve identifiers back to definition sites, emit hits with `depth` + `from` (the enclosing symbol that produced the hit), then add the new names to the next frontier modulo the hub-guard.
- `callees.rs` extended with the two flags and a multi-hop branch. **Defaults are byte-identical to the old single-hop output**: no `depth` / `hub_guard` / `from` fields in JSON, no `[dN]` prefix in text — only when `--depth > 1`.
- Dedup key includes `depth` so the same target reached via different hops keeps its layered context (depth-1 hits aren't shadowed by deeper paths).
- Cycle protection via `visited`: a name is expanded at most once per BFS run, but a back-call to the seed surfaces as a legitimate hit (e.g. `alpha → beta → alpha` emits `alpha` at depth 2; it just isn't expanded again).
- AGENT_GUIDE.md documents the new flags under `callees`.

### Files changed
- `crates/fff-cli/src/commands/callees.rs` — extend Args, branch on depth, restructured Hit/Output payload (additive serde fields)
- `crates/fff-cli/src/commands/callees_bfs.rs` — new (~270 lines, 5 unit tests covering direct hop, multi-hop, hub-guard, cycle, clamp-to-5)
- `crates/fff-cli/src/commands/mod.rs` — `pub(crate) mod callees_bfs;`
- `crates/fff-cli/assets/AGENT_GUIDE.md` — document `--depth` / `--hub-guard`

### Verified locally
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --features zlob -- -D warnings`
- `cargo test --workspace --features zlob --exclude fff-nvim` — all green (5 new BFS tests + the existing 100+ tests untouched)
- Smoke test on this repo:
  - `scry callees --limit 5 collect_callees` (default depth=1) — output byte-identical to before this PR.
  - `scry callees --depth 2 --limit 8 collect_callees` — first 8 still depth-1 because `as_bytes`/`new` saturate hub_guard=50; expected.
  - `scry callees --depth 3 --limit 20 per_hit_budget_bytes` — walks the chain `per_hit_budget_bytes → default_for → custom → percent_budget` across three files with `from` set correctly at each hop.
  - `scry callees --format json --depth 2 ...` — root carries `depth` and `hub_guard`; per-hit carries `depth` and `from`.

## Review & Testing Checklist for Human

- [ ] Run `scry callees <symbol>` with no flags — confirm output byte-identical to pre-PR (no `depth`/`from` per hit, no `[d1]` prefix).
- [ ] Run `scry callees --depth 3 <hub-symbol>` and inspect the BFS chain — verify `from` correctly names the *intermediate* caller at each hop, not the seed.
- [ ] Run `scry callees --depth 3 --hub-guard 0 <hot-symbol>` — expect propagation to stop after depth 1 since every name will exceed the guard.
- [ ] Spot-check that `--depth` values > 5 silently clamp to 5 (the JSON `depth` field reflects the clamped value).

### Notes
- `callees_bfs.rs` is structurally a forward-direction mirror of `callers_bfs.rs`, but they share no code — the call-resolution is fundamentally different (forward = parse body, inverse = bloom-narrowed text scan). Sharing seemed forced; left as parallel files per existing precedent.
- MCP / Lua / C wiring for the new flags is intentionally deferred to B7 per the plan.