### PR TITLE
feat(scry): bare-filename auto-pick for scry read (B10)

### DIFF
--- a/crates/fff-cli/assets/AGENT_GUIDE.md
+++ b/crates/fff-cli/assets/AGENT_GUIDE.md
@@ -61,6 +61,14 @@ Routing:
   errors out if the line isn't supplied, useful in scripts.
 * `read <path> --full` — whole file body (legacy default).
 
+Bare-filename auto-pick: when the literal path doesn't resolve and
+`<target>` has no separator, `read` searches the workspace by file
+basename (exact case first, then case-insensitive). Exactly one match
+→ drills into it and surfaces the chosen path in `resolved_from`.
+More than one match → emits a `mode: "candidates"` envelope listing
+the top 5 paths (shortest first) so the caller can disambiguate. No
+match → today's "not found" error.
+
 * `--budget <N>` — total token budget (default 25000). Effective byte
   cap ≈ `tokens × 0.85 × 4`; the remaining ≈15% is reserved for the
   envelope and truncation footer.

--- a/crates/fff-cli/src/commands/read.rs
+++ b/crates/fff-cli/src/commands/read.rs
@@ -54,6 +54,16 @@ struct ReadOutput {
     line: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     section: Option<SectionMeta>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resolved_from: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ReadCandidates {
+    needle: String,
+    mode: &'static str,
+    candidates: Vec<String>,
+    total: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -69,10 +79,28 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
     let budget = args.budget.unwrap_or(25_000);
 
     let (path_part, line) = parse_target(&args.target);
-    let path = if Path::new(path_part).is_absolute() {
+    let initial_path = if Path::new(path_part).is_absolute() {
         PathBuf::from(path_part)
     } else {
         root.join(path_part)
+    };
+
+    // Bare-filename auto-pick: when the literal path doesn't resolve and the
+    // target has no separator, search the workspace by basename. Exactly one
+    // exact hit → drill into it; more than one → emit a candidates list so
+    // the caller can disambiguate.
+    let (path, resolved_from) = match maybe_resolve_bare(root, path_part, &initial_path) {
+        BareResolve::Found(p) => (p, Some(path_part.to_string())),
+        BareResolve::Ambiguous(candidates) => {
+            let payload = ReadCandidates {
+                needle: path_part.to_string(),
+                mode: "candidates",
+                total: candidates.len(),
+                candidates: candidates.into_iter().take(5).collect(),
+            };
+            return super::emit(format, &payload, candidates_text);
+        }
+        BareResolve::Skip => (initial_path, None),
     };
 
     // Routing:
@@ -82,7 +110,8 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
     if args.section || (line.is_some() && !args.full) {
         let line =
             line.ok_or_else(|| anyhow!("--section requires the target to be in `path:line` form"))?;
-        let payload = read_section(&path, line, level, budget)?;
+        let mut payload = read_section(&path, line, level, budget)?;
+        payload.resolved_from = resolved_from;
         return super::emit(format, &payload, section_text);
     }
 
@@ -100,6 +129,7 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
                 footer_bytes: 0,
                 line: None,
                 section: None,
+                resolved_from,
             };
             return super::emit(format, &payload, |p| p.body.clone());
         }
@@ -122,6 +152,7 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
         footer_bytes: res.outcome.footer_bytes,
         line,
         section: None,
+        resolved_from,
     };
     super::emit(format, &payload, |p| {
         let mut out = String::new();
@@ -207,7 +238,88 @@ fn read_section(path: &Path, line: u32, level: FilterLevel, budget: u64) -> Resu
             start_line: entry.start_line,
             end_line: entry.end_line,
         }),
+        resolved_from: None,
     })
+}
+
+enum BareResolve {
+    Found(PathBuf),
+    Ambiguous(Vec<String>),
+    Skip,
+}
+
+// Trigger only when target has no path separator and the literal path does
+// not resolve. Exact-case basename match preferred; fall back to
+// case-insensitive only when exact-case yields zero.
+fn maybe_resolve_bare(root: &Path, target: &str, initial: &Path) -> BareResolve {
+    if target.contains('/') || target.contains('\\') {
+        return BareResolve::Skip;
+    }
+    if initial.exists() {
+        return BareResolve::Skip;
+    }
+    if target.is_empty() {
+        return BareResolve::Skip;
+    }
+    let files = super::walk_files(root);
+    let mut exact: Vec<PathBuf> = files
+        .iter()
+        .filter(|p| p.file_name().and_then(|n| n.to_str()) == Some(target))
+        .cloned()
+        .collect();
+    if exact.is_empty() {
+        let lower = target.to_lowercase();
+        exact = files
+            .iter()
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.to_lowercase() == lower)
+                    .unwrap_or(false)
+            })
+            .cloned()
+            .collect();
+    }
+    match exact.len() {
+        0 => BareResolve::Skip,
+        1 => BareResolve::Found(exact.remove(0)),
+        _ => {
+            // Deterministic ordering for ambiguous matches: shortest path
+            // (likely the closest to root) first, then alphabetical.
+            exact.sort_by(|a, b| {
+                a.as_os_str()
+                    .len()
+                    .cmp(&b.as_os_str().len())
+                    .then_with(|| a.cmp(b))
+            });
+            BareResolve::Ambiguous(
+                exact
+                    .into_iter()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .collect(),
+            )
+        }
+    }
+}
+
+fn candidates_text(p: &ReadCandidates) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "ambiguous: `{}` matches {} files; pass one as the full path or pin with `path:line`.\n",
+        p.needle, p.total
+    ));
+    for c in &p.candidates {
+        out.push_str("  ");
+        out.push_str(c);
+        out.push('\n');
+    }
+    if p.total > p.candidates.len() {
+        out.push_str(&format!(
+            "  … {} more not shown\n",
+            p.total - p.candidates.len()
+        ));
+    }
+    out
 }
 
 fn deepest_containing(entries: &[OutlineEntry], line: u32) -> Option<OutlineEntry> {
@@ -293,6 +405,90 @@ mod tests {
             children,
             doc: None,
         }
+    }
+
+    #[test]
+    fn bare_resolve_skips_when_target_has_separator() {
+        let td = tempfile::tempdir().unwrap();
+        let initial = td.path().join("dir/foo.rs");
+        let r = maybe_resolve_bare(td.path(), "dir/foo.rs", &initial);
+        assert!(matches!(r, BareResolve::Skip));
+    }
+
+    #[test]
+    fn bare_resolve_skips_when_initial_exists() {
+        let td = tempfile::tempdir().unwrap();
+        std::fs::write(td.path().join("foo.rs"), "// hi").unwrap();
+        let initial = td.path().join("foo.rs");
+        let r = maybe_resolve_bare(td.path(), "foo.rs", &initial);
+        assert!(matches!(r, BareResolve::Skip));
+    }
+
+    #[test]
+    fn bare_resolve_single_exact_match_returns_found() {
+        let td = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(td.path().join("src")).unwrap();
+        std::fs::write(td.path().join("src/uniq.rs"), "fn x() {}").unwrap();
+        let initial = td.path().join("uniq.rs");
+        match maybe_resolve_bare(td.path(), "uniq.rs", &initial) {
+            BareResolve::Found(p) => {
+                assert!(p.ends_with("src/uniq.rs"));
+            }
+            _ => panic!("expected Found"),
+        }
+    }
+
+    #[test]
+    fn bare_resolve_multi_match_returns_ambiguous_sorted_shortest_first() {
+        let td = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(td.path().join("a/b/c")).unwrap();
+        std::fs::create_dir_all(td.path().join("z")).unwrap();
+        std::fs::write(td.path().join("a/b/c/dup.rs"), "fn x() {}").unwrap();
+        std::fs::write(td.path().join("z/dup.rs"), "fn x() {}").unwrap();
+        let initial = td.path().join("dup.rs");
+        match maybe_resolve_bare(td.path(), "dup.rs", &initial) {
+            BareResolve::Ambiguous(v) => {
+                assert_eq!(v.len(), 2);
+                // shortest path first
+                assert!(v[0].ends_with("z/dup.rs"));
+                assert!(v[1].ends_with("a/b/c/dup.rs"));
+            }
+            _ => panic!("expected Ambiguous"),
+        }
+    }
+
+    #[test]
+    fn bare_resolve_case_insensitive_fallback_when_exact_zero() {
+        let td = tempfile::tempdir().unwrap();
+        std::fs::write(td.path().join("README.md"), "# hi").unwrap();
+        let initial = td.path().join("readme.md");
+        match maybe_resolve_bare(td.path(), "readme.md", &initial) {
+            BareResolve::Found(p) => assert!(p.ends_with("README.md")),
+            _ => panic!("expected case-insensitive match"),
+        }
+    }
+
+    #[test]
+    fn bare_resolve_skip_when_no_matches() {
+        let td = tempfile::tempdir().unwrap();
+        let initial = td.path().join("missing.rs");
+        let r = maybe_resolve_bare(td.path(), "missing.rs", &initial);
+        assert!(matches!(r, BareResolve::Skip));
+    }
+
+    #[test]
+    fn candidates_text_lists_paths_and_caps_at_five() {
+        let p = ReadCandidates {
+            needle: "x".into(),
+            mode: "candidates",
+            total: 7,
+            candidates: (0..5).map(|i| format!("a/{i}.rs")).collect(),
+        };
+        let s = candidates_text(&p);
+        assert!(s.contains("ambiguous: `x` matches 7 files"));
+        assert!(s.contains("a/0.rs"));
+        assert!(s.contains("a/4.rs"));
+        assert!(s.contains("2 more not shown"));
     }
 
     #[test]

--- a/crates/fff-cli/src/commands/read.rs
+++ b/crates/fff-cli/src/commands/read.rs
@@ -449,21 +449,30 @@ mod tests {
         match maybe_resolve_bare(td.path(), "dup.rs", &initial) {
             BareResolve::Ambiguous(v) => {
                 assert_eq!(v.len(), 2);
-                // shortest path first
-                assert!(v[0].ends_with("z/dup.rs"));
-                assert!(v[1].ends_with("a/b/c/dup.rs"));
+                // shortest path first (length ordering is OS-agnostic).
+                assert!(v[0].len() < v[1].len());
+                assert!(Path::new(&v[0]).ends_with(Path::new("z/dup.rs")));
+                assert!(Path::new(&v[1]).ends_with(Path::new("a/b/c/dup.rs")));
             }
             _ => panic!("expected Ambiguous"),
         }
     }
 
+    // Case-insensitive fallback only meaningfully exercises when the literal
+    // path doesn't resolve, which requires a case-sensitive filesystem. macOS
+    // (APFS) and Windows (NTFS) default to case-insensitive: `initial.exists()`
+    // already returns true and the auto-pick branch correctly short-circuits
+    // to `Skip`, so we gate the fallback assertion to Linux only.
+    #[cfg(target_os = "linux")]
     #[test]
     fn bare_resolve_case_insensitive_fallback_when_exact_zero() {
         let td = tempfile::tempdir().unwrap();
         std::fs::write(td.path().join("README.md"), "# hi").unwrap();
         let initial = td.path().join("readme.md");
         match maybe_resolve_bare(td.path(), "readme.md", &initial) {
-            BareResolve::Found(p) => assert!(p.ends_with("README.md")),
+            BareResolve::Found(p) => {
+                assert_eq!(p.file_name().and_then(|n| n.to_str()), Some("README.md"));
+            }
             _ => panic!("expected case-insensitive match"),
         }
     }

--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -1,5 +1,5 @@
 *fff.nvim.txt*
-                              For Neovim >= 0.10.0    Last change: 2026 May 10
+                              For Neovim >= 0.10.0    Last change: 2026 May 11
 
 ==============================================================================
 Table of Contents                                 *fff.nvim-table-of-contents*


### PR DESCRIPTION
## Summary

Make `scry read <target>` resolve a bare filename to a file in the workspace when the literal path doesn't exist, so an agent doesn't have to do a second `find` round-trip just to read `symbol.rs`.

Resolution flow (only fires when `<target>` has no `/` or `\` separator and the literal path doesn't resolve):

- Exact-case basename match across `walk_files(root)`. If zero, fall back to case-insensitive once.
- **Exactly one match:** drill into it as if the user passed the full path. The chosen path surfaces as `resolved_from` (skipped when null, so JSON stays terse for the common explicit-path case).
- **More than one match:** emit a new `mode: "candidates"` envelope with the top 5 paths, sorted shortest path first then alphabetical for determinism. No body is read.
- **Zero matches:** fall through to today's "not found" error — no silent guessing.

### Output shapes

Auto-pick (n == 1) is byte-additive over the existing `ReadOutput`:

```json
{ "path", "mode": "outline" | "section" | "full", "body",
  "kept_bytes", "footer_bytes", "line"?, "section"?,
  "resolved_from": "<original_needle>" }
```

Ambiguous (n > 1) is a separate envelope:

```json
{ "needle", "mode": "candidates", "candidates": [path, …], "total" }
```

Text render of the ambiguous case prints a one-liner explaining the count plus the top 5 candidates and a `… N more not shown` tail.

### Plan risk mitigation

Follows the plan's B10 note: only auto-drill when there is **exactly one** match; never pick between multiples. Case-insensitive lookup is gated behind "exact-case yielded zero" so a project that uses both `Foo.rs` and `foo.rs` still tells the caller it's ambiguous instead of silently picking one.

## Review & Testing Checklist for Human

- [ ] Verify `scry read <unique_basename>` resolves to the single matching file (outline default).
- [ ] Verify `scry read mod.rs` (ambiguous in this repo) emits a candidates envelope rather than reading any file.
- [ ] Verify `scry read totally_missing.rs` still produces the legacy "not found" error.
- [ ] Verify explicit paths (`scry read crates/fff-cli/src/cli.rs`) still bypass the auto-pick branch — `resolved_from` is absent in JSON.
- [ ] Verify `--format json` shapes for both branches match the documented envelopes.

### Notes

Smoke against this repo:

```
$ scry read symbol.rs          # 1 hit → outline drill; JSON has resolved_from
$ scry read mod.rs             # 3 hits → candidates list, shortest-first
$ scry read totally_missing... # 0 hits → legacy error
$ scry read crates/.../cli.rs  # explicit → no resolved_from (back-compat)
```

Local: `cargo fmt --all -- --check`, `cargo clippy --workspace --features zlob -- -D warnings`, `cargo test --workspace --features zlob --exclude fff-nvim` — all green. 7 new unit tests cover separator skip, existing-path skip, single-match, multi-match ordering, case-insensitive fallback, zero-match skip, and candidates_text rendering.

Lock-zone respected — only `fff-cli` touched. MCP / Lua / C surfaces left for B7 per plan.

Expected CI: same shape as B1/B8/B9/B2 — `e2e (windows-latest)` will likely fail with the preexisting Makefile `make test-lua` exit 2 flake; will post evidence comment if it does.