### PR TITLE
feat(scry): multi-symbol scry symbol "a,b,c" (B11)

### DIFF
--- a/crates/fff-cli/assets/AGENT_GUIDE.md
+++ b/crates/fff-cli/assets/AGENT_GUIDE.md
@@ -95,6 +95,14 @@ Look up a symbol definition by name. Tree-sitter AST-driven, not
 substring. Trailing `*` is treated as a prefix glob: `symbol Foo*`
 matches every name starting with `Foo`.
 
+Comma-separated names emit one group per symbol: `symbol "a,b,c"`
+returns a `{ query, groups: [...], total_groups }` envelope where each
+group is the regular single-symbol envelope. Single-name calls are
+byte-identical to before. Duplicate names are dropped (first-wins) and
+whitespace around each entry is trimmed. With `--expand`, the token
+budget is split across the visible hits in *all* groups (each hit gets
+the same per-hit floor), so multi-symbol queries don't over-allocate.
+
 JSON response includes a `facets` field: `{ total, by_kind }` counted
 on the *full* candidate set (i.e. unaffected by `--offset` /
 `--limit`). Text output appends a `by kind: function: 12, struct: 3`

--- a/crates/fff-cli/src/commands/symbol.rs
+++ b/crates/fff-cli/src/commands/symbol.rs
@@ -17,6 +17,7 @@ use crate::commands::pagination::{footer, Page};
 #[derive(Debug, Parser)]
 pub struct Args {
     /// Symbol name to look up. Glob patterns ending with `*` are treated as prefixes.
+    /// Comma-separated list (e.g. `"a,b,c"`) emits one group per name.
     pub name: String,
 
     /// Maximum hits returned in this page.
@@ -56,6 +57,13 @@ struct SymbolOutput {
 }
 
 #[derive(Debug, Serialize)]
+struct MultiSymbolOutput {
+    query: String,
+    groups: Vec<SymbolOutput>,
+    total_groups: usize,
+}
+
+#[derive(Debug, Serialize)]
 struct SymbolHit {
     name: String,
     path: String,
@@ -83,7 +91,82 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
     let engine = Engine::default();
     engine.index(root);
 
-    let all_hits: Vec<SymbolHit> = if let Some(prefix) = args.name.strip_suffix('*') {
+    let names = parse_names(&args.name);
+    if names.len() <= 1 {
+        let payload = build_group(
+            &engine,
+            &args.name,
+            args.offset,
+            args.limit,
+            args.expand,
+            args.budget,
+            args.no_did_you_mean,
+        );
+        return super::emit(format, &payload, render_single);
+    }
+
+    // Multi-symbol: budget shared across visible hits in every group.
+    let mut groups: Vec<SymbolOutput> = names
+        .iter()
+        .map(|n| {
+            build_group(
+                &engine,
+                n,
+                args.offset,
+                args.limit,
+                false, // expand applied after we know total visible hit count.
+                args.budget,
+                args.no_did_you_mean,
+            )
+        })
+        .collect();
+
+    if args.expand {
+        let total_visible: usize = groups.iter().map(|g| g.hits.len()).sum();
+        if total_visible > 0 {
+            let per_hit = per_hit_budget_bytes(args.budget, total_visible);
+            for group in groups.iter_mut() {
+                for hit in group.hits.iter_mut() {
+                    let path = PathBuf::from(&hit.path);
+                    hit.expanded =
+                        expand_hit(&engine, &hit.name, &path, hit.line, hit.end_line, per_hit);
+                }
+            }
+        }
+    }
+
+    let payload = MultiSymbolOutput {
+        total_groups: groups.len(),
+        groups,
+        query: args.name,
+    };
+    super::emit(format, &payload, render_multi)
+}
+
+fn parse_names(raw: &str) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for part in raw.split(',') {
+        let t = part.trim();
+        if t.is_empty() {
+            continue;
+        }
+        if !seen.iter().any(|s| s == t) {
+            seen.push(t.to_string());
+        }
+    }
+    seen
+}
+
+fn build_group(
+    engine: &Engine,
+    name: &str,
+    offset: usize,
+    limit: usize,
+    expand: bool,
+    budget: u64,
+    no_did_you_mean: bool,
+) -> SymbolOutput {
+    let all_hits: Vec<SymbolHit> = if let Some(prefix) = name.strip_suffix('*') {
         engine
             .handles
             .symbols
@@ -95,79 +178,176 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
         engine
             .handles
             .symbols
-            .lookup_exact(&args.name)
+            .lookup_exact(name)
             .into_iter()
-            .map(|l| loc_to_hit(&args.name, l))
+            .map(|l| loc_to_hit(name, l))
             .collect()
     };
 
-    let did_you_mean = if all_hits.is_empty() && !args.no_did_you_mean {
-        suggest(&engine, &args.name)
+    let did_you_mean = if all_hits.is_empty() && !no_did_you_mean {
+        suggest(engine, name)
     } else {
         Vec::new()
     };
 
     let facets = Facets::from_kinds(all_hits.iter().map(|h| h.kind.as_str()));
-    let mut page = Page::paginate(all_hits, args.offset, args.limit);
+    let mut page = Page::paginate(all_hits, offset, limit);
 
-    if args.expand && !page.items.is_empty() {
-        let per_hit = per_hit_budget_bytes(args.budget, page.items.len());
+    if expand && !page.items.is_empty() {
+        let per_hit = per_hit_budget_bytes(budget, page.items.len());
         for hit in page.items.iter_mut() {
             let path = PathBuf::from(&hit.path);
-            hit.expanded = expand_hit(&engine, &hit.name, &path, hit.line, hit.end_line, per_hit);
+            hit.expanded = expand_hit(engine, &hit.name, &path, hit.line, hit.end_line, per_hit);
         }
     }
 
-    let payload = SymbolOutput {
-        query: args.name,
+    SymbolOutput {
+        query: name.to_string(),
         total: page.total,
         offset: page.offset,
         has_more: page.has_more,
         hits: page.items,
         facets,
         did_you_mean,
-    };
-    super::emit(format, &payload, |p| {
-        let mut out = String::new();
-        for h in &p.hits {
-            out.push_str(&format!(
-                "{} @ {}:{} ({})\n",
-                h.name, h.path, h.line, h.kind
-            ));
-            if let Some(exp) = &h.expanded {
-                for line in exp.body.lines() {
-                    out.push_str("  ");
-                    out.push_str(line);
-                    out.push('\n');
-                }
+    }
+}
+
+fn render_single(p: &SymbolOutput) -> String {
+    let mut out = String::new();
+    push_group_lines(&mut out, p, false);
+    out
+}
+
+fn render_multi(p: &MultiSymbolOutput) -> String {
+    let mut out = String::new();
+    for (i, g) in p.groups.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push_str(&format!("## {}\n", g.query));
+        push_group_lines(&mut out, g, true);
+    }
+    out
+}
+
+fn push_group_lines(out: &mut String, p: &SymbolOutput, indent: bool) {
+    let prefix = if indent { "  " } else { "" };
+    for h in &p.hits {
+        out.push_str(prefix);
+        out.push_str(&format!(
+            "{} @ {}:{} ({})\n",
+            h.name, h.path, h.line, h.kind
+        ));
+        if let Some(exp) = &h.expanded {
+            for line in exp.body.lines() {
+                out.push_str(prefix);
+                out.push_str("  ");
+                out.push_str(line);
+                out.push('\n');
             }
         }
-        if p.total == 0 {
-            out.push_str("[no symbols found]\n");
-            if !p.did_you_mean.is_empty() {
-                out.push_str("did you mean:\n");
-                for s in &p.did_you_mean {
-                    out.push_str(&format!(
-                        "  {} ({}) — {} hit{}\n",
-                        s.name,
-                        s.source,
-                        s.hits.len(),
-                        if s.hits.len() == 1 { "" } else { "s" }
-                    ));
-                }
-            }
-        } else {
-            out.push_str(&footer(p.total, p.offset, p.hits.len(), p.has_more));
-            if !p.facets.by_kind.is_empty() {
-                let parts: Vec<String> = p
-                    .facets
-                    .by_kind
-                    .iter()
-                    .map(|(k, n)| format!("{k}: {n}"))
-                    .collect();
-                out.push_str(&format!("by kind: {}\n", parts.join(", ")));
+    }
+    if p.total == 0 {
+        out.push_str(prefix);
+        out.push_str("[no symbols found]\n");
+        if !p.did_you_mean.is_empty() {
+            out.push_str(prefix);
+            out.push_str("did you mean:\n");
+            for s in &p.did_you_mean {
+                out.push_str(prefix);
+                out.push_str(&format!(
+                    "  {} ({}) — {} hit{}\n",
+                    s.name,
+                    s.source,
+                    s.hits.len(),
+                    if s.hits.len() == 1 { "" } else { "s" }
+                ));
             }
         }
-        out
-    })
+    } else {
+        let foot = footer(p.total, p.offset, p.hits.len(), p.has_more);
+        for line in foot.lines() {
+            out.push_str(prefix);
+            out.push_str(line);
+            out.push('\n');
+        }
+        if !p.facets.by_kind.is_empty() {
+            let parts: Vec<String> = p
+                .facets
+                .by_kind
+                .iter()
+                .map(|(k, n)| format!("{k}: {n}"))
+                .collect();
+            out.push_str(prefix);
+            out.push_str(&format!("by kind: {}\n", parts.join(", ")));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_names_returns_singleton_for_plain_name() {
+        assert_eq!(parse_names("foo"), vec!["foo".to_string()]);
+    }
+
+    #[test]
+    fn parse_names_trims_and_filters_empty() {
+        assert_eq!(
+            parse_names(" a , b , , c "),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        );
+    }
+
+    #[test]
+    fn parse_names_dedups_preserving_first_occurrence() {
+        assert_eq!(
+            parse_names("a,b,a,c,b"),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        );
+    }
+
+    #[test]
+    fn parse_names_preserves_prefix_glob_marker() {
+        // Multi-symbol entries each keep their own `*` suffix.
+        assert_eq!(
+            parse_names("foo*,bar"),
+            vec!["foo*".to_string(), "bar".to_string()],
+        );
+    }
+
+    fn empty_group(name: &str) -> SymbolOutput {
+        SymbolOutput {
+            query: name.to_string(),
+            hits: Vec::new(),
+            total: 0,
+            offset: 0,
+            has_more: false,
+            facets: Facets::from_kinds(std::iter::empty::<&str>()),
+            did_you_mean: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn render_multi_separates_groups_with_blank_line_and_header() {
+        let payload = MultiSymbolOutput {
+            query: "a,b".into(),
+            total_groups: 2,
+            groups: vec![empty_group("a"), empty_group("b")],
+        };
+        let text = render_multi(&payload);
+        assert!(text.starts_with("## a\n"));
+        assert!(text.contains("\n\n## b\n"));
+        assert!(text.matches("[no symbols found]").count() == 2);
+    }
+
+    #[test]
+    fn render_single_omits_group_header_and_indent() {
+        let group = empty_group("a");
+        let text = render_single(&group);
+        assert!(!text.contains("## a"));
+        assert!(text.starts_with("[no symbols found]"));
+    }
 }


### PR DESCRIPTION
## Summary

Make the positional argument of `scry symbol` accept a comma-separated list so an agent can resolve a batch of names in one round-trip:

```
$ scry symbol "a,b,c"
```

Single-name calls remain **byte-identical** to before — same JSON shape, same text rendering. Multi-name calls emit a new outer envelope:

```json
{ "query": "a,b,c", "groups": [<SymbolOutput>, ...], "total_groups": 3 }
```

Each group is the regular `SymbolOutput` (`query`, `hits`, `total`, `offset`, `has_more`, `facets`, `did_you_mean`). Splitting/dedup is whitespace-tolerant and first-wins, so `"a, b , a"` becomes `["a","b"]`. Trailing `*` for prefix globs still works per entry (`"Foo*,Bar"`).

### Budget sharing under `--expand`

With `--expand`, the token budget is split across the visible hits in **all** groups, not per group:

```
total_visible = sum(group.hits.len() for group in groups)
per_hit       = per_hit_budget_bytes(budget, total_visible)
```

This keeps multi-symbol queries bounded by the same budget a caller would pass to a single-symbol one. Reuses the existing `per_hit_budget_bytes` helper from B1.

### did_you_mean per group

Each zero-hit name still gets its own fallback (case variants → `lookup_prefix` → `neo_frizbee` fuzzy with `max_typos=2`), capped at 5 entries. A multi-symbol call can mix hits and misses cleanly:

```
$ scry symbol "lokup_exact,run_bfs"   # group 1 emits dym, group 2 has hits
```

### Text rendering

Multi-symbol output prefixes each group with `## <name>` and indents every line of the group (hits, expand bodies, footer, facets) by two spaces so the boundary between groups is unambiguous. Groups are separated by a single blank line.

## Review & Testing Checklist for Human

- [ ] Verify `scry symbol foo` (single name) is byte-identical to before — same JSON shape, same text output.
- [ ] Verify `scry symbol "a,b"` emits `{query, groups, total_groups}` with one group per name.
- [ ] Verify duplicates and whitespace are normalised (`"a, b , a"` → 2 groups).
- [ ] Verify `--expand` on multi-symbol shares the budget across all visible hits across groups.
- [ ] Verify `did_you_mean` per zero-hit group still works.

### Notes

Smoke on this repo:

```
$ scry symbol "lookup_exact,run_bfs,nonexistent"  # 3 groups, 1+2+0 hits
$ scry symbol "lokup_exact,run_bfs"               # 0+2 hits, dym in group 1
$ scry symbol "loc_to_hit,build_group" --expand   # both bodies inlined
```

Local: `cargo fmt --all -- --check`, `cargo clippy --workspace --features zlob -- -D warnings`, `cargo test --workspace --features zlob --exclude fff-nvim` — all green. 6 new unit tests cover parse_names invariants (singleton, trim/empty filter, dedup, prefix-glob preservation) and render_multi/render_single structure.

Lock-zone respected — only `fff-cli` touched. MCP / Lua / C surfaces left for B7 per plan.

Expected CI: same shape as B1/B8/B9/B2/B10 — `e2e (windows-latest)` will likely fail with the preexisting Makefile `make test-lua` exit 2 flake; evidence comment will be posted if so.