### PR TITLE
feat(scry): callers --count-by caller|file aggregations (B3)

### DIFF
--- a/crates/fff-cli/assets/AGENT_GUIDE.md
+++ b/crates/fff-cli/assets/AGENT_GUIDE.md
@@ -112,6 +112,16 @@ line under the pagination footer.
 Find lines that reference `<name>` outside its own definition site.
 Bloom-narrowed first, then confirmed with a literal-text pass.
 
+* `--hops N` — multi-hop BFS over the caller graph (default 1, max 5).
+* `--hub-guard N` — stop propagating from any single name that produces
+  more than N hits in one hop (default 50). Hits still surface.
+* `--count-by none|caller|file` — post-BFS frequency table. `caller`
+  groups by the enclosing function/scope, `file` groups by the
+  containing path. JSON gains an `aggregations: [{ key, count }]` field
+  (omitted when `none`, so the default output is byte-identical); text
+  output appends an `Aggregated:` section with `count  key` rows
+  sorted desc, ties alphabetical.
+
 ### `callees <name>`
 Identifiers referenced inside the body of `<name>`, then resolved
 back to definitions via the symbol index. Hits with the same

--- a/crates/fff-cli/src/commands/callers.rs
+++ b/crates/fff-cli/src/commands/callers.rs
@@ -1,11 +1,12 @@
 //! `scry callers <symbol>` — find call sites for `symbol`. With `--hops > 1`
 //! the search becomes a BFS over the caller graph.
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::time::SystemTime;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use serde::Serialize;
 
 use fff_engine::{Engine, PreFilterStack};
@@ -13,7 +14,7 @@ use fff_symbol::lang::detect_file_type;
 use fff_symbol::types::FileType;
 
 use crate::cli::OutputFormat;
-use crate::commands::callers_bfs::{run_bfs, BfsConfig, CandidateFile};
+use crate::commands::callers_bfs::{enclosing_symbol, run_bfs, BfsConfig, CandidateFile};
 use crate::commands::pagination::{footer, Page};
 
 #[derive(Debug, Parser)]
@@ -38,6 +39,20 @@ pub struct Args {
     /// the BFS up.
     #[arg(long, default_value_t = 50)]
     pub hub_guard: usize,
+
+    /// Aggregate hits into a frequency table. `caller` groups by the
+    /// enclosing symbol (function/method/scope); `file` groups by the
+    /// containing path; `none` (default) skips aggregation and keeps the
+    /// output byte-identical.
+    #[arg(long, value_enum, default_value_t = CountBy::None)]
+    pub count_by: CountBy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum CountBy {
+    None,
+    Caller,
+    File,
 }
 
 #[derive(Debug, Serialize)]
@@ -60,6 +75,14 @@ struct CallersOutput {
     total: usize,
     offset: usize,
     has_more: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    aggregations: Option<Vec<Aggregation>>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct Aggregation {
+    pub key: String,
+    pub count: usize,
 }
 
 pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
@@ -86,7 +109,7 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
         })
         .collect();
 
-    let hits = if args.hops <= 1 {
+    let mut hits = if args.hops <= 1 {
         single_hop(&engine, &args.name, &candidates)
     } else {
         run_bfs(
@@ -100,6 +123,11 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
         )
     };
 
+    if args.count_by == CountBy::Caller {
+        populate_enclosing(&engine, &mut hits, &candidates);
+    }
+    let aggregations = aggregate(&hits, args.count_by);
+
     let page = Page::paginate(hits, args.offset, args.limit);
     let payload = CallersOutput {
         name: args.name.clone(),
@@ -109,8 +137,64 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
         offset: page.offset,
         has_more: page.has_more,
         hits: page.items,
+        aggregations,
     };
     super::emit(format, &payload, render_text)
+}
+
+/// Compute frequency table for `hits` keyed by either enclosing symbol or
+/// file path. Returns `None` when `mode == None` so callers can skip emitting
+/// the field entirely (byte-identical default behaviour).
+pub(crate) fn aggregate(hits: &[CallerHit], mode: CountBy) -> Option<Vec<Aggregation>> {
+    if mode == CountBy::None {
+        return None;
+    }
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for h in hits {
+        let key = match mode {
+            CountBy::Caller => h
+                .enclosing
+                .clone()
+                .unwrap_or_else(|| "<unknown>".to_string()),
+            CountBy::File => h.path.clone(),
+            CountBy::None => unreachable!(),
+        };
+        *counts.entry(key).or_default() += 1;
+    }
+    let mut rows: Vec<Aggregation> = counts
+        .into_iter()
+        .map(|(key, count)| Aggregation { key, count })
+        .collect();
+    rows.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.key.cmp(&b.key)));
+    Some(rows)
+}
+
+/// Fill `enclosing` for hits that don't have it yet (single-hop path leaves
+/// it `None`). Uses the outline cache like the BFS path does.
+fn populate_enclosing(engine: &Engine, hits: &mut [CallerHit], candidates: &[CandidateFile]) {
+    let by_path: HashMap<&str, &CandidateFile> = candidates
+        .iter()
+        .map(|c| (c.path.to_str().unwrap_or(""), c))
+        .collect();
+    let mut outline_cache: HashMap<String, Vec<fff_symbol::types::OutlineEntry>> = HashMap::new();
+    for h in hits.iter_mut() {
+        if h.enclosing.is_some() {
+            continue;
+        }
+        let Some(cf) = by_path.get(h.path.as_str()) else {
+            continue;
+        };
+        let Some(lang) = cf.lang else {
+            continue;
+        };
+        let outline = outline_cache.entry(h.path.clone()).or_insert_with(|| {
+            engine
+                .handles
+                .outlines
+                .get_or_compute(&cf.path, cf.mtime, &cf.content, lang)
+        });
+        h.enclosing = enclosing_symbol(outline, h.line);
+    }
 }
 
 fn single_hop(engine: &Engine, name: &str, candidates: &[CandidateFile]) -> Vec<CallerHit> {
@@ -185,5 +269,136 @@ fn render_text(p: &CallersOutput) -> String {
     } else {
         out.push_str(&footer(p.total, p.offset, p.hits.len(), p.has_more));
     }
+    if let Some(aggs) = p.aggregations.as_ref() {
+        out.push_str(&render_aggregations(aggs));
+    }
     out
+}
+
+fn render_aggregations(aggs: &[Aggregation]) -> String {
+    let mut out = String::new();
+    out.push_str("\nAggregated:\n");
+    for a in aggs {
+        out.push_str(&format!("  {:>5}  {}\n", a.count, a.key));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hit(path: &str, enclosing: Option<&str>) -> CallerHit {
+        CallerHit {
+            path: path.to_string(),
+            line: 1,
+            text: String::new(),
+            depth: 1,
+            target: "x".to_string(),
+            enclosing: enclosing.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn aggregate_none_returns_none() {
+        let hits = vec![hit("a", Some("foo"))];
+        assert!(aggregate(&hits, CountBy::None).is_none());
+    }
+
+    #[test]
+    fn aggregate_by_file_groups_by_path() {
+        let hits = vec![
+            hit("src/a.rs", Some("foo")),
+            hit("src/a.rs", Some("bar")),
+            hit("src/b.rs", Some("baz")),
+        ];
+        let aggs = aggregate(&hits, CountBy::File).unwrap();
+        assert_eq!(aggs.len(), 2);
+        assert_eq!(
+            aggs[0],
+            Aggregation {
+                key: "src/a.rs".into(),
+                count: 2
+            }
+        );
+        assert_eq!(
+            aggs[1],
+            Aggregation {
+                key: "src/b.rs".into(),
+                count: 1
+            }
+        );
+    }
+
+    #[test]
+    fn aggregate_by_caller_groups_by_enclosing() {
+        let hits = vec![
+            hit("src/a.rs", Some("foo")),
+            hit("src/a.rs", Some("bar")),
+            hit("src/b.rs", Some("baz")),
+        ];
+        let aggs = aggregate(&hits, CountBy::Caller).unwrap();
+        assert_eq!(aggs.len(), 3);
+        // Counts all 1, sorted alphabetically as tie-break.
+        assert_eq!(aggs[0].key, "bar");
+        assert_eq!(aggs[1].key, "baz");
+        assert_eq!(aggs[2].key, "foo");
+    }
+
+    #[test]
+    fn aggregate_by_caller_falls_back_for_unknown() {
+        let hits = vec![hit("src/a.rs", None), hit("src/a.rs", None)];
+        let aggs = aggregate(&hits, CountBy::Caller).unwrap();
+        assert_eq!(aggs.len(), 1);
+        assert_eq!(
+            aggs[0],
+            Aggregation {
+                key: "<unknown>".into(),
+                count: 2
+            }
+        );
+    }
+
+    #[test]
+    fn render_text_omits_section_when_none() {
+        let payload = CallersOutput {
+            name: "x".into(),
+            hops: 1,
+            hub_guard: 50,
+            hits: vec![CallerHit {
+                path: "a".into(),
+                line: 1,
+                text: "x".into(),
+                depth: 1,
+                target: "x".into(),
+                enclosing: None,
+            }],
+            total: 1,
+            offset: 0,
+            has_more: false,
+            aggregations: None,
+        };
+        let s = render_text(&payload);
+        assert!(!s.contains("Aggregated"));
+    }
+
+    #[test]
+    fn render_text_emits_section_when_present() {
+        let payload = CallersOutput {
+            name: "x".into(),
+            hops: 1,
+            hub_guard: 50,
+            hits: vec![],
+            total: 0,
+            offset: 0,
+            has_more: false,
+            aggregations: Some(vec![Aggregation {
+                key: "foo".into(),
+                count: 2,
+            }]),
+        };
+        let s = render_text(&payload);
+        assert!(s.contains("Aggregated:"));
+        assert!(s.contains("foo"));
+    }
 }

--- a/crates/fff-cli/tests/cli_callers_count_by.rs
+++ b/crates/fff-cli/tests/cli_callers_count_by.rs
@@ -1,0 +1,115 @@
+//! End-to-end tests for `scry callers --count-by` (B3). Verifies that the
+//! aggregation field is opt-in (omitted by default → byte-identical legacy
+//! behaviour) and that `caller` / `file` group keys produce sensible counts
+//! on a synthetic three-call graph spread across two files.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+const TARGET_DEF: &str = "\
+pub fn target() {}
+";
+
+// Two distinct callers (alpha, beta) inside src/a.rs, each calling target() once.
+const A_RS: &str = "\
+pub fn alpha() {
+    target();
+}
+
+pub fn beta() {
+    target();
+}
+";
+
+// One additional caller (gamma) inside src/b.rs.
+const B_RS: &str = "\
+pub fn gamma() {
+    target();
+}
+";
+
+fn binary() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_scry"))
+}
+
+fn write_workspace() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    let src = tmp.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(src.join("target.rs"), TARGET_DEF).unwrap();
+    std::fs::write(src.join("a.rs"), A_RS).unwrap();
+    std::fs::write(src.join("b.rs"), B_RS).unwrap();
+    tmp
+}
+
+fn run(root: &Path, extra: &[&str]) -> Value {
+    let mut cmd = Command::new(binary());
+    cmd.args(["--root", root.to_str().unwrap(), "--format", "json"]);
+    cmd.args(["callers", "target"]);
+    cmd.args(extra);
+    let out = cmd.output().expect("run scry callers");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).expect("parse json")
+}
+
+#[test]
+fn count_by_default_is_none_and_field_is_absent() {
+    let tmp = write_workspace();
+    let v = run(tmp.path(), &[]);
+    // 3 distinct call sites surfaced as hits.
+    assert_eq!(v["total"].as_u64().unwrap(), 3);
+    // No aggregations field when count-by is omitted.
+    assert!(v.get("aggregations").is_none());
+}
+
+#[test]
+fn count_by_file_groups_by_path() {
+    let tmp = write_workspace();
+    let v = run(tmp.path(), &["--count-by", "file"]);
+    let aggs = v["aggregations"].as_array().expect("aggregations array");
+    // a.rs has 2 hits, b.rs has 1 — two distinct paths.
+    assert_eq!(aggs.len(), 2);
+    let counts: Vec<u64> = aggs.iter().map(|a| a["count"].as_u64().unwrap()).collect();
+    assert_eq!(counts, vec![2, 1]);
+    assert!(aggs[0]["key"].as_str().unwrap().ends_with("a.rs"));
+    assert!(aggs[1]["key"].as_str().unwrap().ends_with("b.rs"));
+}
+
+#[test]
+fn count_by_caller_groups_by_enclosing_symbol() {
+    let tmp = write_workspace();
+    let v = run(tmp.path(), &["--count-by", "caller"]);
+    let aggs = v["aggregations"].as_array().expect("aggregations array");
+    // alpha / beta / gamma — three distinct enclosing functions.
+    let mut keys: Vec<String> = aggs
+        .iter()
+        .map(|a| a["key"].as_str().unwrap().to_string())
+        .collect();
+    keys.sort();
+    assert_eq!(keys, vec!["alpha", "beta", "gamma"]);
+    for entry in aggs {
+        assert_eq!(entry["count"].as_u64().unwrap(), 1);
+    }
+}
+
+#[test]
+fn count_by_text_appends_aggregated_section() {
+    let tmp = write_workspace();
+    let out = Command::new(binary())
+        .args(["--root", tmp.path().to_str().unwrap()])
+        .args(["callers", "target", "--count-by", "file"])
+        .output()
+        .expect("run scry callers --count-by file");
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    assert!(stdout.contains("Aggregated:"));
+    assert!(stdout.contains("a.rs"));
+    assert!(stdout.contains("b.rs"));
+}


### PR DESCRIPTION
## Summary

B3 from the Stream B plan: add a post-BFS frequency table to `scry callers` via a new `--count-by <none|caller|file>` flag.

* New `CountBy` value-enum (defaults to `None`, so default output is byte-identical).
* `caller` groups by enclosing symbol; `file` groups by path; `none` skips aggregation.
* JSON gains an `aggregations: [{ key, count }]` field next to `hits`, sorted desc by count with alphabetical tie-break. `skip_serializing_if = Option::is_none`, so JSON callers see no diff with the default.
* Text output appends an `Aggregated:` section with `  count  key` rows (only when the flag is set).
* `caller` mode needs `enclosing` to be populated; single-hop path previously left it `None`. New `populate_enclosing` helper fills it in via the outline cache, only on demand.

Unit + e2e tests added. AGENT_GUIDE updated. Lock zones respected — only `crates/fff-cli` touched.

## Review & Testing Checklist for Human

- [ ] Confirm `scry callers <name>` with no flags still emits byte-identical output.
- [ ] Spot-check `--count-by file --format json`: aggregations sum to hits total.
- [ ] Spot-check `--count-by caller`: rows group by enclosing function.

### Notes

B11 / B12 already merged on main; first PR of the B3 → B4 → B6 → B7 sequence. B4 will branch off this PR.