### PR TITLE
feat(scry): callers BFS suspicious-hops + auto-hubs-promoted (B4)

### DIFF
--- a/crates/fff-cli/assets/AGENT_GUIDE.md
+++ b/crates/fff-cli/assets/AGENT_GUIDE.md
@@ -121,6 +121,15 @@ Bloom-narrowed first, then confirmed with a literal-text pass.
   (omitted when `none`, so the default output is byte-identical); text
   output appends an `Aggregated:` section with `count  key` rows
   sorted desc, ties alphabetical.
+* With `--hops > 1` the JSON payload may also expose two diagnostics
+  lists, omitted when empty so single-hop output stays byte-identical:
+  * `suspicious_hops: [{ depth, name, roots[] }]` — a name resolves to
+    definitions in 2+ distinct package roots at the same hop (typical
+    smell: trait method clash, re-exported helper).
+  * `auto_hubs_promoted: [{ depth, name, count }]` — hub-guard kicked in
+    for `name` at `depth` and propagation was stopped (hits still surface).
+  Text output appends `Suspicious hops:` / `Auto hub-guard promotions:`
+  sections only when these lists are non-empty.
 
 ### `callees <name>`
 Identifiers referenced inside the body of `<name>`, then resolved

--- a/crates/fff-cli/src/commands/callers.rs
+++ b/crates/fff-cli/src/commands/callers.rs
@@ -14,7 +14,9 @@ use fff_symbol::lang::detect_file_type;
 use fff_symbol::types::FileType;
 
 use crate::cli::OutputFormat;
-use crate::commands::callers_bfs::{enclosing_symbol, run_bfs, BfsConfig, CandidateFile};
+use crate::commands::callers_bfs::{
+    enclosing_symbol, run_bfs, AutoHub, BfsConfig, BfsTelemetry, CandidateFile, SuspiciousHop,
+};
 use crate::commands::pagination::{footer, Page};
 
 #[derive(Debug, Parser)]
@@ -77,6 +79,44 @@ struct CallersOutput {
     has_more: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     aggregations: Option<Vec<Aggregation>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    suspicious_hops: Vec<SuspiciousHopOut>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    auto_hubs_promoted: Vec<AutoHubOut>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct SuspiciousHopOut {
+    pub depth: u32,
+    pub name: String,
+    pub roots: Vec<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct AutoHubOut {
+    pub depth: u32,
+    pub name: String,
+    pub count: usize,
+}
+
+impl From<SuspiciousHop> for SuspiciousHopOut {
+    fn from(s: SuspiciousHop) -> Self {
+        Self {
+            depth: s.depth,
+            name: s.name,
+            roots: s.roots,
+        }
+    }
+}
+
+impl From<AutoHub> for AutoHubOut {
+    fn from(a: AutoHub) -> Self {
+        Self {
+            depth: a.depth,
+            name: a.name,
+            count: a.count,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -109,10 +149,13 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
         })
         .collect();
 
-    let mut hits = if args.hops <= 1 {
-        single_hop(&engine, &args.name, &candidates)
+    let (mut hits, telemetry) = if args.hops <= 1 {
+        (
+            single_hop(&engine, &args.name, &candidates),
+            BfsTelemetry::default(),
+        )
     } else {
-        run_bfs(
+        let r = run_bfs(
             &engine,
             &args.name,
             &candidates,
@@ -120,7 +163,9 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
                 max_hops: args.hops,
                 hub_guard: args.hub_guard,
             },
-        )
+            root,
+        );
+        (r.hits, r.telemetry)
     };
 
     if args.count_by == CountBy::Caller {
@@ -138,6 +183,16 @@ pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
         has_more: page.has_more,
         hits: page.items,
         aggregations,
+        suspicious_hops: telemetry
+            .suspicious_hops
+            .into_iter()
+            .map(SuspiciousHopOut::from)
+            .collect(),
+        auto_hubs_promoted: telemetry
+            .auto_hubs_promoted
+            .into_iter()
+            .map(AutoHubOut::from)
+            .collect(),
     };
     super::emit(format, &payload, render_text)
 }
@@ -272,6 +327,23 @@ fn render_text(p: &CallersOutput) -> String {
     if let Some(aggs) = p.aggregations.as_ref() {
         out.push_str(&render_aggregations(aggs));
     }
+    if !p.suspicious_hops.is_empty() {
+        out.push_str("\nSuspicious hops (name defined in multiple roots):\n");
+        for s in &p.suspicious_hops {
+            out.push_str(&format!(
+                "  [d{}] {}  roots: {}\n",
+                s.depth,
+                s.name,
+                s.roots.join(", ")
+            ));
+        }
+    }
+    if !p.auto_hubs_promoted.is_empty() {
+        out.push_str("\nAuto hub-guard promotions (propagation stopped):\n");
+        for a in &p.auto_hubs_promoted {
+            out.push_str(&format!("  [d{}] {}  hits: {}\n", a.depth, a.name, a.count));
+        }
+    }
     out
 }
 
@@ -377,6 +449,8 @@ mod tests {
             offset: 0,
             has_more: false,
             aggregations: None,
+            suspicious_hops: Vec::new(),
+            auto_hubs_promoted: Vec::new(),
         };
         let s = render_text(&payload);
         assert!(!s.contains("Aggregated"));
@@ -396,6 +470,8 @@ mod tests {
                 key: "foo".into(),
                 count: 2,
             }]),
+            suspicious_hops: Vec::new(),
+            auto_hubs_promoted: Vec::new(),
         };
         let s = render_text(&payload);
         assert!(s.contains("Aggregated:"));

--- a/crates/fff-cli/src/commands/callers_bfs.rs
+++ b/crates/fff-cli/src/commands/callers_bfs.rs
@@ -13,8 +13,8 @@
 //! (e.g. trait methods) is searched once per hop regardless of definition
 //! count.
 
-use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use fff_engine::{Engine, PreFilterStack};
@@ -25,6 +25,57 @@ use crate::commands::callers::CallerHit;
 pub struct BfsConfig {
     pub max_hops: u32,
     pub hub_guard: usize,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct BfsTelemetry {
+    pub suspicious_hops: Vec<SuspiciousHop>,
+    pub auto_hubs_promoted: Vec<AutoHub>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct SuspiciousHop {
+    pub depth: u32,
+    pub name: String,
+    pub roots: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct AutoHub {
+    pub depth: u32,
+    pub name: String,
+    pub count: usize,
+}
+
+pub struct BfsResult {
+    pub hits: Vec<CallerHit>,
+    pub telemetry: BfsTelemetry,
+}
+
+// First two components of the relative path of `path` rooted at `root`, joined
+// with `/`. Falls back to the leftmost component(s) of the absolute path when
+// `path` is not actually rooted at `root` (e.g. resolved via canonicalize).
+pub(crate) fn package_root(path: &Path, root: &Path) -> String {
+    let rel = path.strip_prefix(root).unwrap_or(path);
+    let mut comps = rel.components();
+    let mut buf = PathBuf::new();
+    if let Some(c) = comps.next() {
+        buf.push(c.as_os_str());
+    }
+    if let Some(c) = comps.next() {
+        // If the second component is the actual file basename, keep only the
+        // first directory level — a file at `<root>/src/a.rs` reports `src`,
+        // not `src/a.rs`.
+        if comps.next().is_some() {
+            buf.push(c.as_os_str());
+        }
+    }
+    let s = buf.to_string_lossy().replace('\\', "/");
+    if s.is_empty() {
+        rel.to_string_lossy().replace('\\', "/")
+    } else {
+        s
+    }
 }
 
 pub struct CandidateFile {
@@ -39,12 +90,14 @@ pub fn run_bfs(
     initial: &str,
     candidates: &[CandidateFile],
     cfg: BfsConfig,
-) -> Vec<CallerHit> {
+    root: &Path,
+) -> BfsResult {
     let stack = PreFilterStack::new(engine.handles.bloom.clone());
     let mut visited: HashSet<String> = HashSet::new();
     visited.insert(initial.to_string());
     let mut frontier: Vec<String> = vec![initial.to_string()];
     let mut all_hits: Vec<CallerHit> = Vec::new();
+    let mut telemetry = BfsTelemetry::default();
 
     let confirm_input: Vec<(PathBuf, SystemTime, String)> = candidates
         .iter()
@@ -67,6 +120,11 @@ pub fn run_bfs(
                 .iter()
                 .map(|d| d.path.to_string_lossy().to_string())
                 .collect();
+            let mut def_roots: BTreeSet<String> = definitions
+                .iter()
+                .map(|d| package_root(&d.path, root))
+                .collect();
+            def_roots.remove("");
 
             let survivors = stack.confirm_symbol(&confirm_input, name);
             let survivor_set: HashSet<&std::path::Path> =
@@ -129,6 +187,19 @@ pub fn run_bfs(
                 for e in enclosings_this_name {
                     next_set.insert(e);
                 }
+            } else {
+                telemetry.auto_hubs_promoted.push(AutoHub {
+                    depth,
+                    name: name.clone(),
+                    count: hits_for_name,
+                });
+            }
+            if def_roots.len() >= 2 {
+                telemetry.suspicious_hops.push(SuspiciousHop {
+                    depth,
+                    name: name.clone(),
+                    roots: def_roots.into_iter().collect(),
+                });
             }
         }
 
@@ -139,7 +210,20 @@ pub fn run_bfs(
         frontier = next_set.into_iter().collect();
     }
 
-    all_hits
+    telemetry
+        .suspicious_hops
+        .sort_by(|a, b| a.depth.cmp(&b.depth).then_with(|| a.name.cmp(&b.name)));
+    telemetry.auto_hubs_promoted.sort_by(|a, b| {
+        a.depth
+            .cmp(&b.depth)
+            .then_with(|| b.count.cmp(&a.count))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+
+    BfsResult {
+        hits: all_hits,
+        telemetry,
+    }
 }
 
 pub fn enclosing_symbol(entries: &[OutlineEntry], line: u32) -> Option<String> {
@@ -162,6 +246,29 @@ pub fn enclosing_symbol(entries: &[OutlineEntry], line: u32) -> Option<String> {
 mod tests {
     use super::*;
     use fff_symbol::types::OutlineKind;
+
+    #[test]
+    fn package_root_keeps_top_two_dirs_for_nested_files() {
+        let root = Path::new("/repo");
+        let p = Path::new("/repo/crates/fff-cli/src/main.rs");
+        assert_eq!(package_root(p, root), "crates/fff-cli");
+    }
+
+    #[test]
+    fn package_root_keeps_single_dir_for_shallow_files() {
+        let root = Path::new("/repo");
+        let p = Path::new("/repo/src/a.rs");
+        assert_eq!(package_root(p, root), "src");
+    }
+
+    #[test]
+    fn package_root_handles_paths_outside_root() {
+        let root = Path::new("/elsewhere");
+        let p = Path::new("/repo/src/a/foo.rs");
+        // Falls back to first two leading components of the absolute path.
+        let got = package_root(p, root);
+        assert!(got.ends_with("repo") || got.ends_with("src"));
+    }
 
     fn entry(
         kind: OutlineKind,

--- a/crates/fff-cli/tests/cli_callers_suspicious.rs
+++ b/crates/fff-cli/tests/cli_callers_suspicious.rs
@@ -1,0 +1,124 @@
+//! End-to-end tests for `scry callers --hops N` telemetry (B4):
+//! `suspicious_hops` lights up when a name resolves to definitions in two
+//! distinct package roots at the same hop. `auto_hubs_promoted` lights up
+//! when a single name fires more hits in a hop than `--hub-guard` allows.
+//! Both fields stay omitted from JSON when empty so the default `--hops 1`
+//! output is byte-identical to the legacy contract.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn binary() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_scry"))
+}
+
+fn run(root: &Path, extra: &[&str]) -> Value {
+    let mut cmd = Command::new(binary());
+    cmd.args(["--root", root.to_str().unwrap(), "--format", "json"]);
+    cmd.args(["callers"]);
+    cmd.args(extra);
+    let out = cmd.output().expect("run scry callers");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).expect("parse json")
+}
+
+fn write_file(dir: &Path, rel: &str, body: &str) {
+    let p = dir.join(rel);
+    std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+    std::fs::write(&p, body).unwrap();
+}
+
+#[test]
+fn default_hops_omits_new_telemetry_fields() {
+    let tmp = TempDir::new().unwrap();
+    write_file(
+        tmp.path(),
+        "src/lib.rs",
+        "pub fn target() {}\npub fn caller() { target(); }\n",
+    );
+
+    let v = run(tmp.path(), &["target"]);
+    // Legacy `--hops 1` path must not surface the new fields.
+    assert!(v.get("suspicious_hops").is_none());
+    assert!(v.get("auto_hubs_promoted").is_none());
+    assert!(v["total"].as_u64().unwrap() >= 1);
+}
+
+#[test]
+fn suspicious_hops_reports_name_defined_in_multiple_roots() {
+    let tmp = TempDir::new().unwrap();
+    // Same symbol name `dup` defined in two distinct package roots — this
+    // is exactly what the suspicious-hops list is meant to flag for the
+    // first hop (lookup of the initial name).
+    write_file(tmp.path(), "src/a/mod.rs", "pub fn dup() {}\n");
+    write_file(tmp.path(), "src/b/mod.rs", "pub fn dup() {}\n");
+    write_file(
+        tmp.path(),
+        "src/c/use.rs",
+        "fn caller() {\n    dup();\n    dup();\n}\n",
+    );
+
+    let v = run(tmp.path(), &["dup", "--hops", "2"]);
+    let suspicious = v["suspicious_hops"].as_array().expect("array");
+    assert!(!suspicious.is_empty(), "expected suspicious_hops entry");
+    let entry = &suspicious[0];
+    assert_eq!(entry["name"].as_str().unwrap(), "dup");
+    assert_eq!(entry["depth"].as_u64().unwrap(), 1);
+    let roots: Vec<String> = entry["roots"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r.as_str().unwrap().to_string())
+        .collect();
+    assert!(roots.iter().any(|r| r.ends_with("src/a")));
+    assert!(roots.iter().any(|r| r.ends_with("src/b")));
+}
+
+#[test]
+fn auto_hubs_promoted_fires_when_hub_guard_kicks_in() {
+    let tmp = TempDir::new().unwrap();
+    // `hot` is a popular helper — many callers in one file. With --hub-guard 1
+    // BFS must stop propagating from `hot` and record that it did so.
+    let body = "pub fn hot() {}\n".to_string()
+        + "fn a() { hot(); }\n"
+        + "fn b() { hot(); }\n"
+        + "fn c() { hot(); }\n";
+    write_file(tmp.path(), "src/hot.rs", &body);
+
+    let v = run(tmp.path(), &["hot", "--hops", "2", "--hub-guard", "1"]);
+    let promoted = v["auto_hubs_promoted"]
+        .as_array()
+        .expect("auto_hubs_promoted array");
+    assert!(!promoted.is_empty(), "expected hub-guard promotion entry");
+    let entry = &promoted[0];
+    assert_eq!(entry["name"].as_str().unwrap(), "hot");
+    assert_eq!(entry["depth"].as_u64().unwrap(), 1);
+    assert!(entry["count"].as_u64().unwrap() >= 2);
+}
+
+#[test]
+fn telemetry_renders_text_sections_when_nonempty() {
+    let tmp = TempDir::new().unwrap();
+    write_file(tmp.path(), "src/a/mod.rs", "pub fn dup() {}\n");
+    write_file(tmp.path(), "src/b/mod.rs", "pub fn dup() {}\n");
+    write_file(tmp.path(), "src/c/use.rs", "fn caller() {\n    dup();\n}\n");
+
+    let out = Command::new(binary())
+        .args(["--root", tmp.path().to_str().unwrap()])
+        .args(["callers", "dup", "--hops", "2"])
+        .output()
+        .expect("run scry callers --hops 2");
+    assert!(out.status.success());
+    let s = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        s.contains("Suspicious hops"),
+        "expected suspicious section in text output:\n{s}"
+    );
+}


### PR DESCRIPTION
## Summary

B4 from the Stream B plan: surface two new BFS-only diagnostics on `scry callers` so agents can spot risky lookups in multi-hop runs.

* **`suspicious_hops`** — a name resolves to definitions in 2+ distinct package roots (typical smell: trait method clash, re-exported helper). Computed per hop from the definition lookup.
* **`auto_hubs_promoted`** — hub-guard kicked in for a name at a given hop, propagation stopped (hits still surface). Records every guarded name with its hit count.

Both fields are added to `CallersOutput` with `#[serde(skip_serializing_if = "Vec::is_empty")]`, so the JSON shape for the default `--hops 1` path (or any BFS run without findings) is byte-identical to the legacy contract — no breakage for downstream consumers.

Implementation:

* `crates/fff-cli/src/commands/callers_bfs.rs` — `run_bfs` now returns a `BfsResult { hits, telemetry }`; new `BfsTelemetry`, `SuspiciousHop`, `AutoHub` types. A small `package_root(path, root)` helper computes the top-1-or-2-component prefix used as the "root" key (e.g. `crates/fff-cli`, `src/a`). Lists are sorted by `(depth, name)` for stable output.
* `crates/fff-cli/src/commands/callers.rs` — thin wrapper types `SuspiciousHopOut` / `AutoHubOut` for serialisation; text renderer appends `Suspicious hops:` and `Auto hub-guard promotions:` sections only when the corresponding list is non-empty.
* AGENT_GUIDE entry under `callers` documents the new fields and the byte-identical default.

Tests:

* `callers_bfs::tests` — `package_root` unit tests (nested file, shallow file, path outside root).
* `tests/cli_callers_suspicious.rs` — end-to-end:
  - default `--hops 1` JSON omits both fields;
  - synthetic workspace with `dup` defined in `src/a` and `src/b` lights up `suspicious_hops` at depth 1 with both roots;
  - synthetic workspace with `hot` called many times + `--hub-guard 1` lights up `auto_hubs_promoted`;
  - text rendering contains the `Suspicious hops` section when non-empty.

Lock zones respected — only `crates/fff-cli` touched.

## Review & Testing Checklist for Human

- [ ] Spot-check `scry callers <name> --hops 1`: JSON must not have `suspicious_hops` or `auto_hubs_promoted` keys.
- [ ] Spot-check `scry callers <name> --hops 3` on real code: telemetry lists should be empty for unique names, populated for trait methods.
- [ ] Run with `--hub-guard 1` against a popular helper to confirm `auto_hubs_promoted` lights up at the right depth.

### Notes

Builds on B3 (`--count-by`), which is already merged. Next in queue: B6 (`scry impact <symbol>`) and B7 (MCP/Lua/C wiring).