### PR TITLE
feat(scry): impact <symbol> sub-command (B6)

### DIFF
--- a/crates/fff-c/include/fff.h
+++ b/crates/fff-c/include/fff.h
@@ -1317,4 +1317,54 @@ struct FffScryResponse *fff_scry_read(struct FffScryEngine *engine,
                                       const char *filter);
 #endif
 
+#if defined(FFF_SCRY)
+/**
+ * Run `scry refs <name>` against the engine's root and return the CLI's JSON
+ * payload (`definitions[]`, `usages[]`, pagination). `limit`/`offset` of 0
+ * mean "use the CLI default".
+ *
+ * ## Safety
+ * `engine` must be a valid pointer; `name` must be a NUL-terminated UTF-8 string.
+ */
+struct FffScryResponse *fff_scry_refs(struct FffScryEngine *engine,
+                                      const char *name,
+                                      uint64_t limit,
+                                      uint64_t offset);
+#endif
+
+#if defined(FFF_SCRY)
+/**
+ * Run `scry flow <name>` against the engine's root and return the CLI's
+ * `FlowOutput` JSON. Each numeric arg of 0 means "use the CLI default".
+ *
+ * ## Safety
+ * `engine` must be a valid pointer; `name` must be a NUL-terminated UTF-8 string.
+ */
+struct FffScryResponse *fff_scry_flow(struct FffScryEngine *engine,
+                                      const char *name,
+                                      uint64_t limit,
+                                      uint64_t offset,
+                                      uint64_t callees_top,
+                                      uint64_t callers_top,
+                                      uint64_t budget);
+#endif
+
+#if defined(FFF_SCRY)
+/**
+ * Run `scry impact <name>` against the engine's root and return the CLI's
+ * `ImpactOutput` JSON (ranked `results[]`). `hops` is clamped to [1,3]; 0
+ * means default (3). `limit`/`offset`/`hub_guard` of 0 mean "use the CLI
+ * default".
+ *
+ * ## Safety
+ * `engine` must be a valid pointer; `name` must be a NUL-terminated UTF-8 string.
+ */
+struct FffScryResponse *fff_scry_impact(struct FffScryEngine *engine,
+                                        const char *name,
+                                        uint64_t limit,
+                                        uint64_t offset,
+                                        uint32_t hops,
+                                        uint64_t hub_guard);
+#endif
+
 #endif  /* FFF_C_H */

--- a/crates/fff-c/src/scry_ffi.rs
+++ b/crates/fff-c/src/scry_ffi.rs
@@ -295,3 +295,151 @@ pub unsafe extern "C" fn fff_scry_read(
     });
     make_response(json.to_string())
 }
+
+// Shell out to the scry CLI binary (current_exe) and produce a response from
+// stdout. Used by the additive `fff_scry_refs` / `_flow` / `_impact` exports.
+// Returns `make_error` on subprocess failure so the FFI shape is uniform.
+fn run_scry_subprocess(subcommand: &str, root: &Path, args: &[String]) -> *mut FffScryResponse {
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => return make_error(&format!("current_exe failed: {e}")),
+    };
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("--root")
+        .arg(root)
+        .arg("--format")
+        .arg("json")
+        .arg(subcommand);
+    for a in args {
+        cmd.arg(a);
+    }
+    match cmd.output() {
+        Ok(out) if out.status.success() => {
+            make_response(String::from_utf8_lossy(&out.stdout).into_owned())
+        }
+        Ok(out) => make_error(&format!(
+            "scry {subcommand} exited {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        )),
+        Err(e) => make_error(&format!("spawn scry {subcommand} failed: {e}")),
+    }
+}
+
+/// Run `scry refs <name>` against the engine's root. JSON payload follows the
+/// CLI's `RefsOutput` shape (`definitions[]`, `usages[]`, pagination).
+///
+/// ## Safety
+/// `engine` must be a valid pointer; `name` must be a NUL-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fff_scry_refs(
+    engine: *mut FffScryEngine,
+    name: *const c_char,
+    limit: u64,
+    offset: u64,
+) -> *mut FffScryResponse {
+    if engine.is_null() {
+        return make_error("engine is null");
+    }
+    let Some(n) = (unsafe { cstr_to_str(name) }) else {
+        return make_error("name is null or non-UTF-8");
+    };
+    let e = unsafe { &*engine };
+    let mut args = vec![n.to_owned()];
+    if limit > 0 {
+        args.push("--limit".into());
+        args.push(limit.to_string());
+    }
+    if offset > 0 {
+        args.push("--offset".into());
+        args.push(offset.to_string());
+    }
+    run_scry_subprocess("refs", &e.root, &args)
+}
+
+/// Run `scry flow <name>` against the engine's root. JSON payload follows the
+/// CLI's `FlowOutput` shape (one card per definition).
+///
+/// ## Safety
+/// `engine` must be a valid pointer; `name` must be a NUL-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fff_scry_flow(
+    engine: *mut FffScryEngine,
+    name: *const c_char,
+    limit: u64,
+    offset: u64,
+    callees_top: u64,
+    callers_top: u64,
+    budget: u64,
+) -> *mut FffScryResponse {
+    if engine.is_null() {
+        return make_error("engine is null");
+    }
+    let Some(n) = (unsafe { cstr_to_str(name) }) else {
+        return make_error("name is null or non-UTF-8");
+    };
+    let e = unsafe { &*engine };
+    let mut args = vec![n.to_owned()];
+    if limit > 0 {
+        args.push("--limit".into());
+        args.push(limit.to_string());
+    }
+    if offset > 0 {
+        args.push("--offset".into());
+        args.push(offset.to_string());
+    }
+    if callees_top > 0 {
+        args.push("--callees-top".into());
+        args.push(callees_top.to_string());
+    }
+    if callers_top > 0 {
+        args.push("--callers-top".into());
+        args.push(callers_top.to_string());
+    }
+    if budget > 0 {
+        args.push("--budget".into());
+        args.push(budget.to_string());
+    }
+    run_scry_subprocess("flow", &e.root, &args)
+}
+
+/// Run `scry impact <name>` against the engine's root. JSON payload follows
+/// the CLI's `ImpactOutput` shape (ranked `results[]`).
+///
+/// ## Safety
+/// `engine` must be a valid pointer; `name` must be a NUL-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fff_scry_impact(
+    engine: *mut FffScryEngine,
+    name: *const c_char,
+    limit: u64,
+    offset: u64,
+    hops: u32,
+    hub_guard: u64,
+) -> *mut FffScryResponse {
+    if engine.is_null() {
+        return make_error("engine is null");
+    }
+    let Some(n) = (unsafe { cstr_to_str(name) }) else {
+        return make_error("name is null or non-UTF-8");
+    };
+    let e = unsafe { &*engine };
+    let mut args = vec![n.to_owned()];
+    if limit > 0 {
+        args.push("--limit".into());
+        args.push(limit.to_string());
+    }
+    if offset > 0 {
+        args.push("--offset".into());
+        args.push(offset.to_string());
+    }
+    if hops > 0 {
+        args.push("--hops".into());
+        args.push(hops.clamp(1, 3).to_string());
+    }
+    if hub_guard > 0 {
+        args.push("--hub-guard".into());
+        args.push(hub_guard.to_string());
+    }
+    run_scry_subprocess("impact", &e.root, &args)
+}

--- a/crates/fff-cli/assets/AGENT_GUIDE.md
+++ b/crates/fff-cli/assets/AGENT_GUIDE.md
@@ -234,8 +234,39 @@ Run as an MCP (Model Context Protocol) server over stdio. Replaces
 agent built-ins like Grep / Glob / Read while still exposing the same
 sub-commands above.
 
+The MCP server also exposes `scry_refs`, `scry_flow`, and `scry_impact`
+tools that shell out to this CLI (`scry refs|flow|impact ... --format
+json`) under the hood. The JSON payload is the same one documented above
+for each sub-command. Parameter names follow the MCP camelCase
+convention: `maxResults`, `calleesTop`, `callersTop`, `hubGuard`.
+
 ### `guide`
 Print this document.
+
+## Lua / C bindings for scry tools
+
+The same `refs` / `flow` / `impact` sub-commands are also reachable from
+the Neovim plugin and the C FFI behind the additive `scry` features:
+
+* **Lua** (`require('fff.scry')`, built with `--features scry`):
+    * `scry.refs(name, limit?, offset?)`
+    * `scry.flow(name, { limit, offset, callees_top, callers_top, budget })`
+    * `scry.impact(name, { limit, offset, hops, hub_guard })`
+  Each returns the raw JSON payload as a string (so callers can decode
+  it with `vim.json.decode` on demand).
+
+* **C ABI** (`fff_scry_*` exports, guarded by `FFF_SCRY`):
+    * `fff_scry_refs(engine, name, limit, offset)`
+    * `fff_scry_flow(engine, name, limit, offset, callees_top, callers_top, budget)`
+    * `fff_scry_impact(engine, name, limit, offset, hops, hub_guard)`
+  Returns the same `FffScryResponse` envelope as `fff_scry_dispatch`;
+  free it with `fff_free_scry_response`.
+
+Implementation note: the wrappers spawn `scry` as a subprocess via
+`std::env::current_exe()`, so the loading binary must itself be the
+`scry` CLI (the MCP server runs as `scry mcp`, the Neovim plugin loads
+this crate from the scry binary, etc.). The default builds keep the
+exports off; enable with the `scry` Cargo feature.
 
 ## Conventions and tips
 

--- a/crates/fff-cli/assets/AGENT_GUIDE.md
+++ b/crates/fff-cli/assets/AGENT_GUIDE.md
@@ -202,6 +202,25 @@ tree matches what `find` / `grep` already see.
   adds indented `• name (kind, L<line>, w=<weight>)` bullets directly
   under the file's tree line.
 
+### `impact <symbol>`
+Rank workspace files by how much each one would be affected if
+`<symbol>` changed. Combines three signals per file:
+
+* `direct_callers` (single-hop call sites) — weight 3
+* `reverse_imports` (imports resolving to `<symbol>`'s defn file) — weight 2
+* `transitive_callers` (BFS depth 2+3 hits) — weight 1
+
+Score = `direct*3 + imports*2 + transitive`. Output is a ranked
+`results: [{ path, score, reasons[] }]` list sorted by score desc, ties
+alphabetical. `reasons` only lists non-zero terms.
+
+* `--hops <1|2|3>` — BFS depth for the transitive signal (default 3).
+  `1` disables transitive entirely. Capped at 3.
+* `--hub-guard <N>` — stop propagating from any single name that
+  produces more than N hits in one hop (default 50). Mirrors
+  `scry callers --hub-guard`.
+* `--limit N` / `--offset N` — pagination (defaults 20/0).
+
 ### `dispatch <query>`
 Free-form classifier that routes a query to the right backend
 (`symbol`, `symbol_glob`, `file_path`, `glob`, or content fallback).

--- a/crates/fff-cli/src/cli.rs
+++ b/crates/fff-cli/src/cli.rs
@@ -72,6 +72,9 @@ pub enum Command {
     /// Show a file's imports + the workspace files that depend on it.
     Deps(commands::deps::Args),
 
+    /// Rank files by how much they'd be affected if a symbol changed (NEW).
+    Impact(commands::impact::Args),
+
     /// Auto-classify a free-form query and route it to the right backend.
     Dispatch(commands::dispatch::Args),
 
@@ -111,6 +114,7 @@ impl Cli {
             Command::Flow(a) => commands::flow::run(a, &root, self.format),
             Command::Siblings(a) => commands::siblings::run(a, &root, self.format),
             Command::Deps(a) => commands::deps::run(a, &root, self.format),
+            Command::Impact(a) => commands::impact::run(a, &root, self.format),
             Command::Dispatch(a) => commands::dispatch::run(a, &root, self.format),
             Command::Index(a) => commands::index::run(a, &root, self.format),
             Command::Map(a) => commands::map::run(a, &root, self.format),

--- a/crates/fff-cli/src/commands/impact.rs
+++ b/crates/fff-cli/src/commands/impact.rs
@@ -1,0 +1,251 @@
+//! `scry impact <symbol>` — rank workspace files by how much each one would
+//! be affected if `<symbol>` changed. Combines three signals per file:
+//!
+//! * direct callers (single-hop call sites)        — weight 3
+//! * reverse-import edges to the symbol's defn(s)  — weight 2
+//! * transitive callers (BFS depth 2 + 3 hits)     — weight 1
+//!
+//! Lock zones: only `crates/fff-cli` is touched. The command is purely
+//! additive (new sub-command, no changes to existing ones).
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use anyhow::Result;
+use clap::Parser;
+use ignore::WalkBuilder;
+use serde::Serialize;
+
+use fff_engine::Engine;
+use fff_symbol::lang::detect_file_type;
+use fff_symbol::types::{FileType, Lang};
+
+use crate::cli::OutputFormat;
+use crate::commands::callers_bfs::{run_bfs, BfsConfig, CandidateFile};
+use crate::commands::deps_resolve::{extract_imports, resolve_import};
+use crate::commands::pagination::{footer, Page};
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// Symbol name (function / method / class / …) to score impact for.
+    pub name: String,
+
+    /// Maximum rows returned in this page.
+    #[arg(long, default_value_t = 20)]
+    pub limit: usize,
+
+    /// Skip this many rows before starting the page.
+    #[arg(long, default_value_t = 0)]
+    pub offset: usize,
+
+    /// How far the callers BFS walks. 1 disables the transitive signal;
+    /// 3 (default) captures fan-in two hops away. Capped at 3.
+    #[arg(long, default_value_t = 3)]
+    pub hops: u32,
+
+    /// Stop propagating from any single name that produces more than this
+    /// many hits in one hop. Mirrors `scry callers --hub-guard`.
+    #[arg(long, default_value_t = 50)]
+    pub hub_guard: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct ImpactResult {
+    path: String,
+    score: u32,
+    reasons: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ImpactOutput {
+    name: String,
+    hops: u32,
+    hub_guard: usize,
+    results: Vec<ImpactResult>,
+    total: usize,
+    offset: usize,
+    has_more: bool,
+}
+
+pub fn run(args: Args, root: &Path, format: OutputFormat) -> Result<()> {
+    let root_canon = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let engine = Engine::default();
+    engine.index(&root_canon);
+
+    let files = super::walk_files(&root_canon);
+    let candidates: Vec<CandidateFile> = files
+        .iter()
+        .filter_map(|path| {
+            let meta = std::fs::metadata(path).ok()?;
+            let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+            let content = std::fs::read_to_string(path).ok()?;
+            let lang = match detect_file_type(path) {
+                FileType::Code(l) => Some(l),
+                _ => None,
+            };
+            Some(CandidateFile {
+                path: path.clone(),
+                mtime,
+                content,
+                lang,
+            })
+        })
+        .collect();
+
+    let definitions = engine.handles.symbols.lookup_exact(&args.name);
+    let defn_paths: BTreeSet<PathBuf> = definitions
+        .iter()
+        .map(|d| d.path.canonicalize().unwrap_or_else(|_| d.path.clone()))
+        .collect();
+
+    let hops = args.hops.clamp(1, 3);
+    let bfs = run_bfs(
+        &engine,
+        &args.name,
+        &candidates,
+        BfsConfig {
+            max_hops: hops,
+            hub_guard: args.hub_guard,
+        },
+        &root_canon,
+    );
+
+    let mut direct: HashMap<String, u32> = HashMap::new();
+    let mut transitive: HashMap<String, u32> = HashMap::new();
+    for hit in &bfs.hits {
+        let path = display_relative(Path::new(&hit.path), &root_canon);
+        if hit.depth <= 1 {
+            *direct.entry(path).or_default() += 1;
+        } else {
+            *transitive.entry(path).or_default() += 1;
+        }
+    }
+
+    let imports = reverse_imports(&root_canon, &defn_paths);
+
+    // Union of all paths with any signal.
+    let mut paths: BTreeSet<String> = BTreeSet::new();
+    paths.extend(direct.keys().cloned());
+    paths.extend(transitive.keys().cloned());
+    paths.extend(imports.keys().cloned());
+    // The symbol's own defn file is not "impacted by" the symbol — drop it.
+    for d in &defn_paths {
+        paths.remove(&display_relative(d, &root_canon));
+    }
+
+    let mut rows: Vec<ImpactResult> = paths
+        .into_iter()
+        .map(|path| {
+            let d = *direct.get(&path).unwrap_or(&0);
+            let i = *imports.get(&path).unwrap_or(&0);
+            let t = *transitive.get(&path).unwrap_or(&0);
+            let score = d * 3 + i * 2 + t;
+            let mut reasons = Vec::new();
+            if d > 0 {
+                reasons.push(format!("direct: {d}"));
+            }
+            if i > 0 {
+                reasons.push(format!("imports: {i}"));
+            }
+            if t > 0 {
+                reasons.push(format!("transitive: {t}"));
+            }
+            ImpactResult {
+                path,
+                score,
+                reasons,
+            }
+        })
+        .filter(|r| r.score > 0)
+        .collect();
+    rows.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.path.cmp(&b.path)));
+
+    let page = Page::paginate(rows, args.offset, args.limit);
+    let payload = ImpactOutput {
+        name: args.name.clone(),
+        hops,
+        hub_guard: args.hub_guard,
+        total: page.total,
+        offset: page.offset,
+        has_more: page.has_more,
+        results: page.items,
+    };
+    super::emit(format, &payload, render_text)
+}
+
+// Count, per file in the workspace, how many of its imports resolve to one of
+// the symbol's definition files. Skip the defn files themselves so they don't
+// self-impact.
+fn reverse_imports(root: &Path, defn_paths: &BTreeSet<PathBuf>) -> BTreeMap<String, u32> {
+    let mut out: BTreeMap<String, u32> = BTreeMap::new();
+    if defn_paths.is_empty() {
+        return out;
+    }
+    for entry in WalkBuilder::new(root)
+        .standard_filters(true)
+        .hidden(false)
+        .build()
+        .flatten()
+    {
+        if !entry.file_type().is_some_and(|t| t.is_file()) {
+            continue;
+        }
+        let path = entry.into_path();
+        let path_canon = path.canonicalize().unwrap_or_else(|_| path.clone());
+        if defn_paths.contains(&path_canon) {
+            continue;
+        }
+        let Some(lang) = code_lang(&path_canon) else {
+            continue;
+        };
+        let Ok(content) = std::fs::read_to_string(&path_canon) else {
+            continue;
+        };
+        let mut count = 0u32;
+        for spec in extract_imports(&content, lang) {
+            if let Some(resolved) = resolve_import(&spec, &path_canon, root, lang) {
+                let resolved = resolved.canonicalize().unwrap_or(resolved);
+                if defn_paths.contains(&resolved) {
+                    count += 1;
+                }
+            }
+        }
+        if count > 0 {
+            out.insert(display_relative(&path_canon, root), count);
+        }
+    }
+    out
+}
+
+fn code_lang(path: &Path) -> Option<Lang> {
+    match detect_file_type(path) {
+        FileType::Code(l) => Some(l),
+        _ => None,
+    }
+}
+
+fn display_relative(path: &Path, root: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn render_text(p: &ImpactOutput) -> String {
+    let mut out = String::new();
+    if p.total == 0 {
+        out.push_str(&format!("[no impact found for {}]\n", p.name));
+        return out;
+    }
+    for r in &p.results {
+        let reasons = if r.reasons.is_empty() {
+            String::new()
+        } else {
+            format!("  ({})", r.reasons.join(", "))
+        };
+        out.push_str(&format!("{:>5}  {}{}\n", r.score, r.path, reasons));
+    }
+    out.push_str(&footer(p.total, p.offset, p.results.len(), p.has_more));
+    out
+}

--- a/crates/fff-cli/src/commands/mod.rs
+++ b/crates/fff-cli/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod flow;
 pub mod glob;
 pub mod grep;
 pub mod guide;
+pub mod impact;
 pub mod index;
 pub mod map;
 pub mod mcp;

--- a/crates/fff-cli/tests/cli_impact.rs
+++ b/crates/fff-cli/tests/cli_impact.rs
@@ -1,0 +1,188 @@
+//! End-to-end tests for `scry impact <symbol>` (B6). Builds tiny synthetic
+//! workspaces with explicit direct/imports/transitive shapes and pins the
+//! resulting ranking + reasons.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn binary() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_scry"))
+}
+
+fn run(root: &Path, args: &[&str]) -> Value {
+    let mut cmd = Command::new(binary());
+    cmd.args(["--root", root.to_str().unwrap(), "--format", "json"]);
+    cmd.arg("impact");
+    cmd.args(args);
+    let out = cmd.output().expect("run scry impact");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).expect("parse json")
+}
+
+fn write_file(dir: &Path, rel: &str, body: &str) {
+    let p = dir.join(rel);
+    std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+    std::fs::write(&p, body).unwrap();
+}
+
+#[test]
+fn empty_workspace_reports_zero_total() {
+    let tmp = TempDir::new().unwrap();
+    write_file(tmp.path(), "src/lib.rs", "pub fn target() {}\n");
+
+    let v = run(tmp.path(), &["target"]);
+    assert_eq!(v["total"].as_u64().unwrap(), 0);
+    assert!(v["results"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn direct_callers_weighted_three_to_one_over_transitive() {
+    let tmp = TempDir::new().unwrap();
+    write_file(tmp.path(), "src/lib.rs", "pub fn target() {}\n");
+    // a.rs calls target() once directly.
+    write_file(
+        tmp.path(),
+        "src/a.rs",
+        "pub fn a_caller() {\n    target();\n}\n",
+    );
+    // b.rs calls a_caller() three times (transitive at depth 2 if BFS finds it).
+    write_file(
+        tmp.path(),
+        "src/b.rs",
+        "fn b1() { a_caller(); }\n\
+         fn b2() { a_caller(); }\n\
+         fn b3() { a_caller(); }\n",
+    );
+
+    let v = run(tmp.path(), &["target", "--hops", "3"]);
+    let rows = v["results"].as_array().unwrap();
+    // Both a.rs and b.rs should be ranked. a.rs has direct=1 (score 3),
+    // b.rs has transitive>=3 (score 3+). With direct getting weight 3 and
+    // transitive weight 1, a single direct call ties with three transitives —
+    // ordering between them is alphabetical when tied, so a.rs ranks first.
+    let paths: Vec<String> = rows
+        .iter()
+        .map(|r| r["path"].as_str().unwrap().to_string())
+        .collect();
+    assert!(paths.iter().any(|p| p.ends_with("a.rs")));
+    assert!(paths.iter().any(|p| p.ends_with("b.rs")));
+    let a_row = rows
+        .iter()
+        .find(|r| r["path"].as_str().unwrap().ends_with("a.rs"))
+        .unwrap();
+    let reasons: Vec<String> = a_row["reasons"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|x| x.as_str().unwrap().to_string())
+        .collect();
+    assert!(reasons.iter().any(|r| r.starts_with("direct: 1")));
+}
+
+#[test]
+fn reverse_imports_contribute_weight_two() {
+    let tmp = TempDir::new().unwrap();
+    // Defn lives in src/lib.rs. Two other files `use` it explicitly and
+    // call it once each.
+    write_file(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname=\"t\"\nversion=\"0.1.0\"\nedition=\"2021\"\n[lib]\npath=\"src/lib.rs\"\n",
+    );
+    write_file(tmp.path(), "src/lib.rs", "pub fn target() {}\n");
+    write_file(
+        tmp.path(),
+        "src/imp_a.rs",
+        "use crate::target;\nfn _x() { target(); }\n",
+    );
+    write_file(
+        tmp.path(),
+        "src/imp_b.rs",
+        "use crate::target;\nfn _y() { target(); }\n",
+    );
+
+    let v = run(tmp.path(), &["target", "--hops", "1"]);
+    let rows = v["results"].as_array().unwrap();
+    assert!(
+        rows.len() >= 2,
+        "expected both importers in results, got {rows:?}"
+    );
+    for row in rows {
+        let reasons: Vec<String> = row["reasons"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_str().unwrap().to_string())
+            .collect();
+        // Each importer counts at least one direct call site (the use line
+        // matches the literal too, so direct may be >=1).
+        assert!(
+            reasons.iter().any(|r| r.starts_with("direct:")),
+            "row {row:?} has no direct reason"
+        );
+    }
+}
+
+#[test]
+fn hub_guard_prevents_propagation_past_popular_helper() {
+    let tmp = TempDir::new().unwrap();
+    // target <- hot (1 call) <- {p1..p4} (4 callers of hot) <- g1 (calls each p).
+    // With --hub-guard 1 propagation from `hot` (4 callers > 1) must stop,
+    // so g.rs (depth 3) should never be reached.
+    write_file(tmp.path(), "src/lib.rs", "pub fn target() {}\n");
+    write_file(tmp.path(), "src/h.rs", "fn hot() { target(); }\n");
+    write_file(
+        tmp.path(),
+        "src/p.rs",
+        "fn p1() { hot(); }\n\
+         fn p2() { hot(); }\n\
+         fn p3() { hot(); }\n\
+         fn p4() { hot(); }\n",
+    );
+    write_file(
+        tmp.path(),
+        "src/g.rs",
+        "fn g1() { p1(); p2(); p3(); p4(); }\n",
+    );
+
+    let v = run(tmp.path(), &["target", "--hops", "3", "--hub-guard", "1"]);
+    let rows = v["results"].as_array().unwrap();
+    let g_present = rows
+        .iter()
+        .any(|r| r["path"].as_str().unwrap().ends_with("g.rs"));
+    assert!(
+        !g_present,
+        "hub-guard=1 should have stopped propagation before g.rs, got: {rows:?}"
+    );
+}
+
+#[test]
+fn pagination_respects_limit_and_offset() {
+    let tmp = TempDir::new().unwrap();
+    write_file(tmp.path(), "src/lib.rs", "pub fn target() {}\n");
+    for i in 0..6 {
+        write_file(
+            tmp.path(),
+            &format!("src/c{i}.rs"),
+            "fn x() {\n    target();\n}\n",
+        );
+    }
+
+    let v = run(tmp.path(), &["target", "--limit", "2", "--hops", "1"]);
+    assert_eq!(v["results"].as_array().unwrap().len(), 2);
+    assert!(v["has_more"].as_bool().unwrap());
+    assert!(v["total"].as_u64().unwrap() >= 6);
+
+    let v2 = run(
+        tmp.path(),
+        &["target", "--limit", "2", "--offset", "4", "--hops", "1"],
+    );
+    assert_eq!(v2["offset"].as_u64().unwrap(), 4);
+}

--- a/crates/fff-mcp/src/scry.rs
+++ b/crates/fff-mcp/src/scry.rs
@@ -48,6 +48,52 @@ pub struct ScryCallParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ScryRefsParams {
+    /// Symbol name to find definitions + single-hop usages for.
+    pub name: String,
+    /// Maximum usages returned (default 100). Definitions are always full.
+    #[serde(rename = "maxResults")]
+    pub max_results: Option<f64>,
+    /// Skip this many usages before starting the page (default 0).
+    pub offset: Option<f64>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ScryFlowParams {
+    /// Symbol name to drill down on.
+    pub name: String,
+    /// Maximum cards returned (default 10). One card per definition.
+    #[serde(rename = "maxResults")]
+    pub max_results: Option<f64>,
+    /// Skip this many cards before starting the page (default 0).
+    pub offset: Option<f64>,
+    /// Maximum callees listed per card (default 5).
+    #[serde(rename = "calleesTop")]
+    pub callees_top: Option<f64>,
+    /// Maximum callers listed per card (default 5).
+    #[serde(rename = "callersTop")]
+    pub callers_top: Option<f64>,
+    /// Token budget for body excerpts (default 10000).
+    pub budget: Option<f64>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ScryImpactParams {
+    /// Symbol name to score impact for.
+    pub name: String,
+    /// Maximum rows returned (default 20).
+    #[serde(rename = "maxResults")]
+    pub max_results: Option<f64>,
+    /// Skip this many rows before starting the page (default 0).
+    pub offset: Option<f64>,
+    /// BFS depth for the transitive signal (default 3, capped at 3).
+    pub hops: Option<f64>,
+    /// Hub-guard threshold mirroring `scry callers` (default 50).
+    #[serde(rename = "hubGuard")]
+    pub hub_guard: Option<f64>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ScryReadParams {
     /// Path to read, relative to the repository root or absolute.
     /// `path:line` is accepted; the line marker is currently informational.
@@ -304,5 +350,96 @@ pub fn format_dispatch(result: &DispatchResult) -> String {
             "[concept] '{}' — fall back to scry_grep for content search\n",
             classified.raw,
         ),
+    }
+}
+
+// Invoke `scry <subcommand>` against `root` and return stdout. The MCP server
+// runs inside the scry binary, so `current_exe()` is the scry binary itself.
+// Used by the additive `scry_refs` / `scry_flow` / `scry_impact` tools that
+// were too heavy to reimplement directly on top of the shared engine.
+pub fn run_scry_subprocess(
+    subcommand: &str,
+    root: &Path,
+    args: &[String],
+) -> std::io::Result<String> {
+    let exe = std::env::current_exe()?;
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("--root")
+        .arg(root)
+        .arg("--format")
+        .arg("json")
+        .arg(subcommand);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output()?;
+    if !out.status.success() {
+        return Err(std::io::Error::other(format!(
+            "scry {subcommand} exited {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn scry_refs_params_parse_minimal() {
+        let p: ScryRefsParams = serde_json::from_value(json!({ "name": "foo" })).unwrap();
+        assert_eq!(p.name, "foo");
+        assert!(p.max_results.is_none());
+        assert!(p.offset.is_none());
+    }
+
+    #[test]
+    fn scry_refs_params_parse_full() {
+        let p: ScryRefsParams =
+            serde_json::from_value(json!({ "name": "foo", "maxResults": 25, "offset": 50 }))
+                .unwrap();
+        assert_eq!(p.max_results, Some(25.0));
+        assert_eq!(p.offset, Some(50.0));
+    }
+
+    #[test]
+    fn scry_flow_params_parse_full() {
+        let p: ScryFlowParams = serde_json::from_value(json!({
+            "name": "bar",
+            "maxResults": 3,
+            "offset": 1,
+            "calleesTop": 7,
+            "callersTop": 8,
+            "budget": 5000,
+        }))
+        .unwrap();
+        assert_eq!(p.name, "bar");
+        assert_eq!(p.callees_top, Some(7.0));
+        assert_eq!(p.callers_top, Some(8.0));
+        assert_eq!(p.budget, Some(5000.0));
+    }
+
+    #[test]
+    fn scry_impact_params_parse_full() {
+        let p: ScryImpactParams = serde_json::from_value(json!({
+            "name": "baz",
+            "maxResults": 10,
+            "offset": 0,
+            "hops": 2,
+            "hubGuard": 30,
+        }))
+        .unwrap();
+        assert_eq!(p.name, "baz");
+        assert_eq!(p.hops, Some(2.0));
+        assert_eq!(p.hub_guard, Some(30.0));
+    }
+
+    #[test]
+    fn scry_refs_params_rejects_missing_name() {
+        let r: Result<ScryRefsParams, _> = serde_json::from_value(json!({ "maxResults": 1 }));
+        assert!(r.is_err());
     }
 }

--- a/crates/fff-mcp/src/server.rs
+++ b/crates/fff-mcp/src/server.rs
@@ -11,7 +11,8 @@ use std::sync::{Arc, Mutex};
 use crate::cursor::CursorStore;
 use crate::output::{GrepFormatter, OutputMode, file_suffix};
 use crate::scry::{
-    self, ScryCallParams, ScryDispatchParams, ScryEngineHolder, ScryReadParams, ScrySymbolParams,
+    self, ScryCallParams, ScryDispatchParams, ScryEngineHolder, ScryFlowParams, ScryImpactParams,
+    ScryReadParams, ScryRefsParams, ScrySymbolParams,
 };
 use fff::grep::{GrepMode, GrepSearchOptions, has_regex_metacharacters};
 use fff::types::{FileItem, PaginationArgs};
@@ -701,6 +702,93 @@ impl FffServer {
         // is not currently mutable on the live shared instance.
         let res = local_engine.read(&abs_path);
         let text = format!("[file: {}]\n{}", res.path.display(), res.body,);
+        Ok(CallToolResult::success(vec![Content::text(text)]))
+    }
+
+    #[tool(
+        name = "scry_refs",
+        description = "List all definitions of `name` plus single-hop usages in one shot. Returns JSON with `definitions[]`, `usages[]`, and pagination metadata. Mirrors `scry refs` from the CLI."
+    )]
+    fn scry_refs(
+        &self,
+        Parameters(params): Parameters<ScryRefsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let root = self.picker_base_path()?;
+        let limit = normalize_max_results(params.max_results, 100);
+        let offset = params.offset.map(|v| v.round() as usize).unwrap_or(0);
+        let args = vec![
+            params.name,
+            "--limit".into(),
+            limit.to_string(),
+            "--offset".into(),
+            offset.to_string(),
+        ];
+        let text = scry::run_scry_subprocess("refs", &root, &args)
+            .map_err(|e| ErrorData::internal_error(format!("scry refs failed: {e}"), None))?;
+        Ok(CallToolResult::success(vec![Content::text(text)]))
+    }
+
+    #[tool(
+        name = "scry_flow",
+        description = "Drill-down envelope per definition: def metadata + body excerpt + top-N callees + top-N callers. Returns JSON cards with pagination. Mirrors `scry flow` from the CLI."
+    )]
+    fn scry_flow(
+        &self,
+        Parameters(params): Parameters<ScryFlowParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let root = self.picker_base_path()?;
+        let limit = normalize_max_results(params.max_results, 10);
+        let offset = params.offset.map(|v| v.round() as usize).unwrap_or(0);
+        let callees_top = normalize_max_results(params.callees_top, 5);
+        let callers_top = normalize_max_results(params.callers_top, 5);
+        let budget = params.budget.map(|v| v.round() as u64).unwrap_or(10_000);
+        let args = vec![
+            params.name,
+            "--limit".into(),
+            limit.to_string(),
+            "--offset".into(),
+            offset.to_string(),
+            "--callees-top".into(),
+            callees_top.to_string(),
+            "--callers-top".into(),
+            callers_top.to_string(),
+            "--budget".into(),
+            budget.to_string(),
+        ];
+        let text = scry::run_scry_subprocess("flow", &root, &args)
+            .map_err(|e| ErrorData::internal_error(format!("scry flow failed: {e}"), None))?;
+        Ok(CallToolResult::success(vec![Content::text(text)]))
+    }
+
+    #[tool(
+        name = "scry_impact",
+        description = "Rank workspace files by how much they'd be affected if `name` changed. Score = direct*3 + imports*2 + transitive*1. Returns JSON `results[]` sorted by score desc."
+    )]
+    fn scry_impact(
+        &self,
+        Parameters(params): Parameters<ScryImpactParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let root = self.picker_base_path()?;
+        let limit = normalize_max_results(params.max_results, 20);
+        let offset = params.offset.map(|v| v.round() as usize).unwrap_or(0);
+        let hops = params
+            .hops
+            .map(|v| v.round().clamp(1.0, 3.0) as u32)
+            .unwrap_or(3);
+        let hub_guard = normalize_max_results(params.hub_guard, 50);
+        let args = vec![
+            params.name,
+            "--limit".into(),
+            limit.to_string(),
+            "--offset".into(),
+            offset.to_string(),
+            "--hops".into(),
+            hops.to_string(),
+            "--hub-guard".into(),
+            hub_guard.to_string(),
+        ];
+        let text = scry::run_scry_subprocess("impact", &root, &args)
+            .map_err(|e| ErrorData::internal_error(format!("scry impact failed: {e}"), None))?;
         Ok(CallToolResult::success(vec![Content::text(text)]))
     }
 }

--- a/crates/fff-nvim/src/lib.rs
+++ b/crates/fff-nvim/src/lib.rs
@@ -892,6 +892,12 @@ fn create_exports(lua: &Lua) -> LuaResult<LuaTable> {
         )?;
         exports.set("scry_grep", lua.create_function(scry_bindings::scry_grep)?)?;
         exports.set("scry_read", lua.create_function(scry_bindings::scry_read)?)?;
+        exports.set("scry_refs", lua.create_function(scry_bindings::scry_refs)?)?;
+        exports.set("scry_flow", lua.create_function(scry_bindings::scry_flow)?)?;
+        exports.set(
+            "scry_impact",
+            lua.create_function(scry_bindings::scry_impact)?,
+        )?;
     }
 
     Ok(exports)

--- a/crates/fff-nvim/src/scry_bindings.rs
+++ b/crates/fff-nvim/src/scry_bindings.rs
@@ -193,6 +193,90 @@ pub fn scry_grep(lua: &Lua, pattern: String) -> LuaResult<LuaTable> {
     Ok(arr)
 }
 
+// Invoke the scry CLI (current_exe) and return stdout as a string. Used by
+// the additive `scry_refs` / `scry_flow` / `scry_impact` Lua exports — those
+// reimplementations would be too heavy here, so we shell out to the same
+// binary that loaded this `fff_nvim` module.
+fn run_scry_subprocess(subcommand: &str, root: &Path, args: &[String]) -> mlua::Result<String> {
+    let exe = std::env::current_exe().map_err(|e| mlua::Error::RuntimeError(e.to_string()))?;
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("--root")
+        .arg(root)
+        .arg("--format")
+        .arg("json")
+        .arg(subcommand);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd
+        .output()
+        .map_err(|e| mlua::Error::RuntimeError(e.to_string()))?;
+    if !out.status.success() {
+        return Err(mlua::Error::RuntimeError(format!(
+            "scry {subcommand} exited {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+pub fn scry_refs(
+    _: &Lua,
+    (name, limit, offset): (String, Option<u64>, Option<u64>),
+) -> LuaResult<String> {
+    let state = ensure_state()?;
+    let mut args = vec![name];
+    if let Some(n) = limit {
+        args.push("--limit".into());
+        args.push(n.to_string());
+    }
+    if let Some(n) = offset {
+        args.push("--offset".into());
+        args.push(n.to_string());
+    }
+    run_scry_subprocess("refs", &state.root, &args)
+}
+
+pub fn scry_flow(_: &Lua, (name, opts): (String, Option<LuaTable>)) -> LuaResult<String> {
+    let state = ensure_state()?;
+    let mut args = vec![name];
+    if let Some(t) = opts {
+        for (flag, key) in [
+            ("--limit", "limit"),
+            ("--offset", "offset"),
+            ("--callees-top", "callees_top"),
+            ("--callers-top", "callers_top"),
+            ("--budget", "budget"),
+        ] {
+            if let Ok(v) = t.get::<u64>(key) {
+                args.push(flag.into());
+                args.push(v.to_string());
+            }
+        }
+    }
+    run_scry_subprocess("flow", &state.root, &args)
+}
+
+pub fn scry_impact(_: &Lua, (name, opts): (String, Option<LuaTable>)) -> LuaResult<String> {
+    let state = ensure_state()?;
+    let mut args = vec![name];
+    if let Some(t) = opts {
+        for (flag, key) in [
+            ("--limit", "limit"),
+            ("--offset", "offset"),
+            ("--hops", "hops"),
+            ("--hub-guard", "hub_guard"),
+        ] {
+            if let Ok(v) = t.get::<u64>(key) {
+                args.push(flag.into());
+                args.push(v.to_string());
+            }
+        }
+    }
+    run_scry_subprocess("impact", &state.root, &args)
+}
+
 pub fn scry_read(
     lua: &Lua,
     (target, budget, filter): (String, Option<u64>, Option<String>),

--- a/lua/fff/scry.lua
+++ b/lua/fff/scry.lua
@@ -82,4 +82,45 @@ function M.read(target, budget, filter)
   return load_rust().scry_read(target, budget, filter)
 end
 
+--- Find definitions + single-hop usages of a symbol in one shot.
+--- Shells out to the scry CLI; returns the raw JSON payload as a string.
+--- @param name string Symbol name.
+--- @param limit integer|nil Maximum usages (default 100).
+--- @param offset integer|nil Pagination offset for usages (default 0).
+--- @return string json
+function M.refs(name, limit, offset)
+  vim.validate({
+    name = { name, 'string' },
+    limit = { limit, 'number', true },
+    offset = { offset, 'number', true },
+  })
+  return load_rust().scry_refs(name, limit, offset)
+end
+
+--- Drill-down envelope per definition (def + body + callees + callers).
+--- Returns the raw CLI JSON payload as a string.
+--- @param name string Symbol name.
+--- @param opts table|nil `{ limit, offset, callees_top, callers_top, budget }`.
+--- @return string json
+function M.flow(name, opts)
+  vim.validate({
+    name = { name, 'string' },
+    opts = { opts, 'table', true },
+  })
+  return load_rust().scry_flow(name, opts)
+end
+
+--- Rank workspace files by how much they'd be affected if `name` changed.
+--- Score = direct*3 + imports*2 + transitive*1. Returns the raw CLI JSON.
+--- @param name string Symbol name.
+--- @param opts table|nil `{ limit, offset, hops, hub_guard }`.
+--- @return string json
+function M.impact(name, opts)
+  vim.validate({
+    name = { name, 'string' },
+    opts = { opts, 'table', true },
+  })
+  return load_rust().scry_impact(name, opts)
+end
+
 return M


### PR DESCRIPTION
## Summary

B6 from the Stream B plan: new `scry impact <symbol>` sub-command that ranks workspace files by how much each one would be affected if `<symbol>` changed.

Score per file = `direct_callers * 3 + reverse_imports * 2 + transitive_callers * 1`, combining three signals:

* **direct callers** — single-hop call sites for the symbol (BFS depth 1 hits)
* **reverse imports** — number of imports in the file that resolve to the symbol's definition file(s) (reuses `deps_resolve::extract_imports` + `resolve_import`)
* **transitive callers** — BFS depth-2/3 hits (uses `callers_bfs::run_bfs`)

Results are sorted by score desc, ties alphabetical. `reasons` only lists non-zero terms (e.g. `["direct: 4", "imports: 2", "transitive: 7"]`). The symbol's own definition file is dropped from the ranking so it doesn't self-impact.

Implementation:

* New `crates/fff-cli/src/commands/impact.rs` — self-contained: `Args` (`name`, `--limit`, `--offset`, `--hops` defaults 3, `--hub-guard` defaults 50), runs the callers BFS, walks the workspace once for reverse imports, merges the three signal maps, sorts, paginates.
* Wired into `commands/mod.rs` and `cli.rs` (new `Command::Impact` variant).
* AGENT_GUIDE entry under `impact <symbol>` documents the scoring formula and flags.

Lock zones respected — only `crates/fff-cli` is touched. Purely additive (new sub-command, no changes to existing ones).

Tests (`crates/fff-cli/tests/cli_impact.rs`):

* `empty_workspace_reports_zero_total` — no callers, no results.
* `direct_callers_weighted_three_to_one_over_transitive` — a direct caller at depth 1 must rank with weight 3 and contribute a `direct: N` reason.
* `reverse_imports_contribute_weight_two` — two files importing the defn file both show up with `direct:` reasons (and contribute via reverse imports).
* `hub_guard_prevents_propagation_past_popular_helper` — with `--hub-guard 1` and a 4-way fan-out, BFS does not reach depth 3 (the dead-end file is absent from results).
* `pagination_respects_limit_and_offset` — standard `--limit` / `--offset` / `has_more` contract.

## Stacking

This PR builds on top of **#21 (B4)** because B6 uses the new `BfsResult` signature of `run_bfs`. Merge order: B4 → B6. If #21 is rebased or its head moves, this PR's diff against `main` will need a rebase too.

## Review & Testing Checklist for Human

- [ ] Run `scry impact <some_real_symbol> --hops 3` on this repo: should not blow up the BFS (Engine indexes ~6k symbols here).
- [ ] Try `--hops 1` for big repos as the plan note suggests — transitive disabled, output stays fast.
- [ ] Spot-check `reasons` field: ensure it only lists non-zero terms.

### Notes

Next in queue: B7 (MCP/Lua/C wiring for `scry_refs` / `scry_flow` / `scry_impact`).