### PR TITLE
feat(scry): wire refs / flow / impact through MCP, Lua, and C (B7)

### DIFF
--- a/crates/fff-c/include/fff.h
+++ b/crates/fff-c/include/fff.h
@@ -1317,4 +1317,54 @@ struct FffScryResponse *fff_scry_read(struct FffScryEngine *engine,
                                       const char *filter);
 #endif
 
+#if defined(FFF_SCRY)
+/**
+ * Run `scry refs <name>` against the engine's root and return the CLI's JSON
+ * payload (`definitions[]`, `usages[]`, pagination). `limit`/`offset` of 0
+ * mean "use the CLI default".
+ *
+ * ## Safety
+ * `engine` must be a valid pointer; `name` must be a NUL-terminated UTF-8 string.
+ */
+struct FffScryResponse *fff_scry_refs(struct FffScryEngine *engine,
+                                      const char *name,
+                                      uint64_t limit,
+                                      uint64_t offset);
+#endif
+
+#if defined(FFF_SCRY)
+/**
+ * Run `scry flow <name>` against the engine's root and return the CLI's
+ * `FlowOutput` JSON. Each numeric arg of 0 means "use the CLI default".
+ *
+ * ## Safety
+ * `engine` must be a valid pointer; `name` must be a NUL-terminated UTF-8 string.
+ */
+struct FffScryResponse *fff_scry_flow(struct FffScryEngine *engine,
+                                      const char *name,
+                                      uint64_t limit,
+                                      uint64_t offset,
+                                      uint64_t callees_top,
+                                      uint64_t callers_top,
+                                      uint64_t budget);
+#endif
+
+#if defined(FFF_SCRY)
+/**
+ * Run `scry impact <name>` against the engine's root and return the CLI's
+ * `ImpactOutput` JSON (ranked `results[]`). `hops` is clamped to [1,3]; 0
+ * means default (3). `limit`/`offset`/`hub_guard` of 0 mean "use the CLI
+ * default".
+ *
+ * ## Safety
+ * `engine` must be a valid pointer; `name` must be a NUL-terminated UTF-8 string.
+ */
+struct FffScryResponse *fff_scry_impact(struct FffScryEngine *engine,
+                                        const char *name,
+                                        uint64_t limit,
+                                        uint64_t offset,
+                                        uint32_t hops,
+                                        uint64_t hub_guard);
+#endif
+
 #endif  /* FFF_C_H */

--- a/crates/fff-c/src/scry_ffi.rs
+++ b/crates/fff-c/src/scry_ffi.rs
@@ -295,3 +295,151 @@ pub unsafe extern "C" fn fff_scry_read(
     });
     make_response(json.to_string())
 }
+
+// Shell out to the scry CLI binary (current_exe) and produce a response from
+// stdout. Used by the additive `fff_scry_refs` / `_flow` / `_impact` exports.
+// Returns `make_error` on subprocess failure so the FFI shape is uniform.
+fn run_scry_subprocess(subcommand: &str, root: &Path, args: &[String]) -> *mut FffScryResponse {
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => return make_error(&format!("current_exe failed: {e}")),
+    };
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("--root")
+        .arg(root)
+        .arg("--format")
+        .arg("json")
+        .arg(subcommand);
+    for a in args {
+        cmd.arg(a);
+    }
+    match cmd.output() {
+        Ok(out) if out.status.success() => {
+            make_response(String::from_utf8_lossy(&out.stdout).into_owned())
+        }
+        Ok(out) => make_error(&format!(
+            "scry {subcommand} exited {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        )),
+        Err(e) => make_error(&format!("spawn scry {subcommand} failed: {e}")),
+    }
+}
+
+/// Run `scry refs <name>` against the engine's root. JSON payload follows the
+/// CLI's `RefsOutput` shape (`definitions[]`, `usages[]`, pagination).
+///
+/// ## Safety
+/// `engine` must be a valid pointer; `name` must be a NUL-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fff_scry_refs(
+    engine: *mut FffScryEngine,
+    name: *const c_char,
+    limit: u64,
+    offset: u64,
+) -> *mut FffScryResponse {
+    if engine.is_null() {
+        return make_error("engine is null");
+    }
+    let Some(n) = (unsafe { cstr_to_str(name) }) else {
+        return make_error("name is null or non-UTF-8");
+    };
+    let e = unsafe { &*engine };
+    let mut args = vec![n.to_owned()];
+    if limit > 0 {
+        args.push("--limit".into());
+        args.push(limit.to_string());
+    }
+    if offset > 0 {
+        args.push("--offset".into());
+        args.push(offset.to_string());
+    }
+    run_scry_subprocess("refs", &e.root, &args)
+}
+
+/// Run `scry flow <name>` against the engine's root. JSON payload follows the
+/// CLI's `FlowOutput` shape (one card per definition).
+///
+/// ## Safety
+/// `engine` must be a valid pointer; `name` must be a NUL-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fff_scry_flow(
+    engine: *mut FffScryEngine,
+    name: *const c_char,
+    limit: u64,
+    offset: u64,
+    callees_top: u64,
+    callers_top: u64,
+    budget: u64,
+) -> *mut FffScryResponse {
+    if engine.is_null() {
+        return make_error("engine is null");
+    }
+    let Some(n) = (unsafe { cstr_to_str(name) }) else {
+        return make_error("name is null or non-UTF-8");
+    };
+    let e = unsafe { &*engine };
+    let mut args = vec![n.to_owned()];
+    if limit > 0 {
+        args.push("--limit".into());
+        args.push(limit.to_string());
+    }
+    if offset > 0 {
+        args.push("--offset".into());
+        args.push(offset.to_string());
+    }
+    if callees_top > 0 {
+        args.push("--callees-top".into());
+        args.push(callees_top.to_string());
+    }
+    if callers_top > 0 {
+        args.push("--callers-top".into());
+        args.push(callers_top.to_string());
+    }
+    if budget > 0 {
+        args.push("--budget".into());
+        args.push(budget.to_string());
+    }
+    run_scry_subprocess("flow", &e.root, &args)
+}
+
+/// Run `scry impact <name>` against the engine's root. JSON payload follows
+/// the CLI's `ImpactOutput` shape (ranked `results[]`).
+///
+/// ## Safety
+/// `engine` must be a valid pointer; `name` must be a NUL-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fff_scry_impact(
+    engine: *mut FffScryEngine,
+    name: *const c_char,
+    limit: u64,
+    offset: u64,
+    hops: u32,
+    hub_guard: u64,
+) -> *mut FffScryResponse {
+    if engine.is_null() {
+        return make_error("engine is null");
+    }
+    let Some(n) = (unsafe { cstr_to_str(name) }) else {
+        return make_error("name is null or non-UTF-8");
+    };
+    let e = unsafe { &*engine };
+    let mut args = vec![n.to_owned()];
+    if limit > 0 {
+        args.push("--limit".into());
+        args.push(limit.to_string());
+    }
+    if offset > 0 {
+        args.push("--offset".into());
+        args.push(offset.to_string());
+    }
+    if hops > 0 {
+        args.push("--hops".into());
+        args.push(hops.clamp(1, 3).to_string());
+    }
+    if hub_guard > 0 {
+        args.push("--hub-guard".into());
+        args.push(hub_guard.to_string());
+    }
+    run_scry_subprocess("impact", &e.root, &args)
+}

--- a/crates/fff-cli/assets/AGENT_GUIDE.md
+++ b/crates/fff-cli/assets/AGENT_GUIDE.md
@@ -234,8 +234,39 @@ Run as an MCP (Model Context Protocol) server over stdio. Replaces
 agent built-ins like Grep / Glob / Read while still exposing the same
 sub-commands above.
 
+The MCP server also exposes `scry_refs`, `scry_flow`, and `scry_impact`
+tools that shell out to this CLI (`scry refs|flow|impact ... --format
+json`) under the hood. The JSON payload is the same one documented above
+for each sub-command. Parameter names follow the MCP camelCase
+convention: `maxResults`, `calleesTop`, `callersTop`, `hubGuard`.
+
 ### `guide`
 Print this document.
+
+## Lua / C bindings for scry tools
+
+The same `refs` / `flow` / `impact` sub-commands are also reachable from
+the Neovim plugin and the C FFI behind the additive `scry` features:
+
+* **Lua** (`require('fff.scry')`, built with `--features scry`):
+    * `scry.refs(name, limit?, offset?)`
+    * `scry.flow(name, { limit, offset, callees_top, callers_top, budget })`
+    * `scry.impact(name, { limit, offset, hops, hub_guard })`
+  Each returns the raw JSON payload as a string (so callers can decode
+  it with `vim.json.decode` on demand).
+
+* **C ABI** (`fff_scry_*` exports, guarded by `FFF_SCRY`):
+    * `fff_scry_refs(engine, name, limit, offset)`
+    * `fff_scry_flow(engine, name, limit, offset, callees_top, callers_top, budget)`
+    * `fff_scry_impact(engine, name, limit, offset, hops, hub_guard)`
+  Returns the same `FffScryResponse` envelope as `fff_scry_dispatch`;
+  free it with `fff_free_scry_response`.
+
+Implementation note: the wrappers spawn `scry` as a subprocess via
+`std::env::current_exe()`, so the loading binary must itself be the
+`scry` CLI (the MCP server runs as `scry mcp`, the Neovim plugin loads
+this crate from the scry binary, etc.). The default builds keep the
+exports off; enable with the `scry` Cargo feature.
 
 ## Conventions and tips
 

--- a/crates/fff-mcp/src/scry.rs
+++ b/crates/fff-mcp/src/scry.rs
@@ -48,6 +48,52 @@ pub struct ScryCallParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ScryRefsParams {
+    /// Symbol name to find definitions + single-hop usages for.
+    pub name: String,
+    /// Maximum usages returned (default 100). Definitions are always full.
+    #[serde(rename = "maxResults")]
+    pub max_results: Option<f64>,
+    /// Skip this many usages before starting the page (default 0).
+    pub offset: Option<f64>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ScryFlowParams {
+    /// Symbol name to drill down on.
+    pub name: String,
+    /// Maximum cards returned (default 10). One card per definition.
+    #[serde(rename = "maxResults")]
+    pub max_results: Option<f64>,
+    /// Skip this many cards before starting the page (default 0).
+    pub offset: Option<f64>,
+    /// Maximum callees listed per card (default 5).
+    #[serde(rename = "calleesTop")]
+    pub callees_top: Option<f64>,
+    /// Maximum callers listed per card (default 5).
+    #[serde(rename = "callersTop")]
+    pub callers_top: Option<f64>,
+    /// Token budget for body excerpts (default 10000).
+    pub budget: Option<f64>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ScryImpactParams {
+    /// Symbol name to score impact for.
+    pub name: String,
+    /// Maximum rows returned (default 20).
+    #[serde(rename = "maxResults")]
+    pub max_results: Option<f64>,
+    /// Skip this many rows before starting the page (default 0).
+    pub offset: Option<f64>,
+    /// BFS depth for the transitive signal (default 3, capped at 3).
+    pub hops: Option<f64>,
+    /// Hub-guard threshold mirroring `scry callers` (default 50).
+    #[serde(rename = "hubGuard")]
+    pub hub_guard: Option<f64>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ScryReadParams {
     /// Path to read, relative to the repository root or absolute.
     /// `path:line` is accepted; the line marker is currently informational.
@@ -304,5 +350,96 @@ pub fn format_dispatch(result: &DispatchResult) -> String {
             "[concept] '{}' — fall back to scry_grep for content search\n",
             classified.raw,
         ),
+    }
+}
+
+// Invoke `scry <subcommand>` against `root` and return stdout. The MCP server
+// runs inside the scry binary, so `current_exe()` is the scry binary itself.
+// Used by the additive `scry_refs` / `scry_flow` / `scry_impact` tools that
+// were too heavy to reimplement directly on top of the shared engine.
+pub fn run_scry_subprocess(
+    subcommand: &str,
+    root: &Path,
+    args: &[String],
+) -> std::io::Result<String> {
+    let exe = std::env::current_exe()?;
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("--root")
+        .arg(root)
+        .arg("--format")
+        .arg("json")
+        .arg(subcommand);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output()?;
+    if !out.status.success() {
+        return Err(std::io::Error::other(format!(
+            "scry {subcommand} exited {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn scry_refs_params_parse_minimal() {
+        let p: ScryRefsParams = serde_json::from_value(json!({ "name": "foo" })).unwrap();
+        assert_eq!(p.name, "foo");
+        assert!(p.max_results.is_none());
+        assert!(p.offset.is_none());
+    }
+
+    #[test]
+    fn scry_refs_params_parse_full() {
+        let p: ScryRefsParams =
+            serde_json::from_value(json!({ "name": "foo", "maxResults": 25, "offset": 50 }))
+                .unwrap();
+        assert_eq!(p.max_results, Some(25.0));
+        assert_eq!(p.offset, Some(50.0));
+    }
+
+    #[test]
+    fn scry_flow_params_parse_full() {
+        let p: ScryFlowParams = serde_json::from_value(json!({
+            "name": "bar",
+            "maxResults": 3,
+            "offset": 1,
+            "calleesTop": 7,
+            "callersTop": 8,
+            "budget": 5000,
+        }))
+        .unwrap();
+        assert_eq!(p.name, "bar");
+        assert_eq!(p.callees_top, Some(7.0));
+        assert_eq!(p.callers_top, Some(8.0));
+        assert_eq!(p.budget, Some(5000.0));
+    }
+
+    #[test]
+    fn scry_impact_params_parse_full() {
+        let p: ScryImpactParams = serde_json::from_value(json!({
+            "name": "baz",
+            "maxResults": 10,
+            "offset": 0,
+            "hops": 2,
+            "hubGuard": 30,
+        }))
+        .unwrap();
+        assert_eq!(p.name, "baz");
+        assert_eq!(p.hops, Some(2.0));
+        assert_eq!(p.hub_guard, Some(30.0));
+    }
+
+    #[test]
+    fn scry_refs_params_rejects_missing_name() {
+        let r: Result<ScryRefsParams, _> = serde_json::from_value(json!({ "maxResults": 1 }));
+        assert!(r.is_err());
     }
 }

--- a/crates/fff-mcp/src/server.rs
+++ b/crates/fff-mcp/src/server.rs
@@ -11,7 +11,8 @@ use std::sync::{Arc, Mutex};
 use crate::cursor::CursorStore;
 use crate::output::{GrepFormatter, OutputMode, file_suffix};
 use crate::scry::{
-    self, ScryCallParams, ScryDispatchParams, ScryEngineHolder, ScryReadParams, ScrySymbolParams,
+    self, ScryCallParams, ScryDispatchParams, ScryEngineHolder, ScryFlowParams, ScryImpactParams,
+    ScryReadParams, ScryRefsParams, ScrySymbolParams,
 };
 use fff::grep::{GrepMode, GrepSearchOptions, has_regex_metacharacters};
 use fff::types::{FileItem, PaginationArgs};
@@ -701,6 +702,93 @@ impl FffServer {
         // is not currently mutable on the live shared instance.
         let res = local_engine.read(&abs_path);
         let text = format!("[file: {}]\n{}", res.path.display(), res.body,);
+        Ok(CallToolResult::success(vec![Content::text(text)]))
+    }
+
+    #[tool(
+        name = "scry_refs",
+        description = "List all definitions of `name` plus single-hop usages in one shot. Returns JSON with `definitions[]`, `usages[]`, and pagination metadata. Mirrors `scry refs` from the CLI."
+    )]
+    fn scry_refs(
+        &self,
+        Parameters(params): Parameters<ScryRefsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let root = self.picker_base_path()?;
+        let limit = normalize_max_results(params.max_results, 100);
+        let offset = params.offset.map(|v| v.round() as usize).unwrap_or(0);
+        let args = vec![
+            params.name,
+            "--limit".into(),
+            limit.to_string(),
+            "--offset".into(),
+            offset.to_string(),
+        ];
+        let text = scry::run_scry_subprocess("refs", &root, &args)
+            .map_err(|e| ErrorData::internal_error(format!("scry refs failed: {e}"), None))?;
+        Ok(CallToolResult::success(vec![Content::text(text)]))
+    }
+
+    #[tool(
+        name = "scry_flow",
+        description = "Drill-down envelope per definition: def metadata + body excerpt + top-N callees + top-N callers. Returns JSON cards with pagination. Mirrors `scry flow` from the CLI."
+    )]
+    fn scry_flow(
+        &self,
+        Parameters(params): Parameters<ScryFlowParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let root = self.picker_base_path()?;
+        let limit = normalize_max_results(params.max_results, 10);
+        let offset = params.offset.map(|v| v.round() as usize).unwrap_or(0);
+        let callees_top = normalize_max_results(params.callees_top, 5);
+        let callers_top = normalize_max_results(params.callers_top, 5);
+        let budget = params.budget.map(|v| v.round() as u64).unwrap_or(10_000);
+        let args = vec![
+            params.name,
+            "--limit".into(),
+            limit.to_string(),
+            "--offset".into(),
+            offset.to_string(),
+            "--callees-top".into(),
+            callees_top.to_string(),
+            "--callers-top".into(),
+            callers_top.to_string(),
+            "--budget".into(),
+            budget.to_string(),
+        ];
+        let text = scry::run_scry_subprocess("flow", &root, &args)
+            .map_err(|e| ErrorData::internal_error(format!("scry flow failed: {e}"), None))?;
+        Ok(CallToolResult::success(vec![Content::text(text)]))
+    }
+
+    #[tool(
+        name = "scry_impact",
+        description = "Rank workspace files by how much they'd be affected if `name` changed. Score = direct*3 + imports*2 + transitive*1. Returns JSON `results[]` sorted by score desc."
+    )]
+    fn scry_impact(
+        &self,
+        Parameters(params): Parameters<ScryImpactParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let root = self.picker_base_path()?;
+        let limit = normalize_max_results(params.max_results, 20);
+        let offset = params.offset.map(|v| v.round() as usize).unwrap_or(0);
+        let hops = params
+            .hops
+            .map(|v| v.round().clamp(1.0, 3.0) as u32)
+            .unwrap_or(3);
+        let hub_guard = normalize_max_results(params.hub_guard, 50);
+        let args = vec![
+            params.name,
+            "--limit".into(),
+            limit.to_string(),
+            "--offset".into(),
+            offset.to_string(),
+            "--hops".into(),
+            hops.to_string(),
+            "--hub-guard".into(),
+            hub_guard.to_string(),
+        ];
+        let text = scry::run_scry_subprocess("impact", &root, &args)
+            .map_err(|e| ErrorData::internal_error(format!("scry impact failed: {e}"), None))?;
         Ok(CallToolResult::success(vec![Content::text(text)]))
     }
 }

--- a/crates/fff-nvim/src/lib.rs
+++ b/crates/fff-nvim/src/lib.rs
@@ -892,6 +892,12 @@ fn create_exports(lua: &Lua) -> LuaResult<LuaTable> {
         )?;
         exports.set("scry_grep", lua.create_function(scry_bindings::scry_grep)?)?;
         exports.set("scry_read", lua.create_function(scry_bindings::scry_read)?)?;
+        exports.set("scry_refs", lua.create_function(scry_bindings::scry_refs)?)?;
+        exports.set("scry_flow", lua.create_function(scry_bindings::scry_flow)?)?;
+        exports.set(
+            "scry_impact",
+            lua.create_function(scry_bindings::scry_impact)?,
+        )?;
     }
 
     Ok(exports)

--- a/crates/fff-nvim/src/scry_bindings.rs
+++ b/crates/fff-nvim/src/scry_bindings.rs
@@ -193,6 +193,90 @@ pub fn scry_grep(lua: &Lua, pattern: String) -> LuaResult<LuaTable> {
     Ok(arr)
 }
 
+// Invoke the scry CLI (current_exe) and return stdout as a string. Used by
+// the additive `scry_refs` / `scry_flow` / `scry_impact` Lua exports — those
+// reimplementations would be too heavy here, so we shell out to the same
+// binary that loaded this `fff_nvim` module.
+fn run_scry_subprocess(subcommand: &str, root: &Path, args: &[String]) -> mlua::Result<String> {
+    let exe = std::env::current_exe().map_err(|e| mlua::Error::RuntimeError(e.to_string()))?;
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("--root")
+        .arg(root)
+        .arg("--format")
+        .arg("json")
+        .arg(subcommand);
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd
+        .output()
+        .map_err(|e| mlua::Error::RuntimeError(e.to_string()))?;
+    if !out.status.success() {
+        return Err(mlua::Error::RuntimeError(format!(
+            "scry {subcommand} exited {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+pub fn scry_refs(
+    _: &Lua,
+    (name, limit, offset): (String, Option<u64>, Option<u64>),
+) -> LuaResult<String> {
+    let state = ensure_state()?;
+    let mut args = vec![name];
+    if let Some(n) = limit {
+        args.push("--limit".into());
+        args.push(n.to_string());
+    }
+    if let Some(n) = offset {
+        args.push("--offset".into());
+        args.push(n.to_string());
+    }
+    run_scry_subprocess("refs", &state.root, &args)
+}
+
+pub fn scry_flow(_: &Lua, (name, opts): (String, Option<LuaTable>)) -> LuaResult<String> {
+    let state = ensure_state()?;
+    let mut args = vec![name];
+    if let Some(t) = opts {
+        for (flag, key) in [
+            ("--limit", "limit"),
+            ("--offset", "offset"),
+            ("--callees-top", "callees_top"),
+            ("--callers-top", "callers_top"),
+            ("--budget", "budget"),
+        ] {
+            if let Ok(v) = t.get::<u64>(key) {
+                args.push(flag.into());
+                args.push(v.to_string());
+            }
+        }
+    }
+    run_scry_subprocess("flow", &state.root, &args)
+}
+
+pub fn scry_impact(_: &Lua, (name, opts): (String, Option<LuaTable>)) -> LuaResult<String> {
+    let state = ensure_state()?;
+    let mut args = vec![name];
+    if let Some(t) = opts {
+        for (flag, key) in [
+            ("--limit", "limit"),
+            ("--offset", "offset"),
+            ("--hops", "hops"),
+            ("--hub-guard", "hub_guard"),
+        ] {
+            if let Ok(v) = t.get::<u64>(key) {
+                args.push(flag.into());
+                args.push(v.to_string());
+            }
+        }
+    }
+    run_scry_subprocess("impact", &state.root, &args)
+}
+
 pub fn scry_read(
     lua: &Lua,
     (target, budget, filter): (String, Option<u64>, Option<String>),

--- a/lua/fff/scry.lua
+++ b/lua/fff/scry.lua
@@ -82,4 +82,45 @@ function M.read(target, budget, filter)
   return load_rust().scry_read(target, budget, filter)
 end
 
+--- Find definitions + single-hop usages of a symbol in one shot.
+--- Shells out to the scry CLI; returns the raw JSON payload as a string.
+--- @param name string Symbol name.
+--- @param limit integer|nil Maximum usages (default 100).
+--- @param offset integer|nil Pagination offset for usages (default 0).
+--- @return string json
+function M.refs(name, limit, offset)
+  vim.validate({
+    name = { name, 'string' },
+    limit = { limit, 'number', true },
+    offset = { offset, 'number', true },
+  })
+  return load_rust().scry_refs(name, limit, offset)
+end
+
+--- Drill-down envelope per definition (def + body + callees + callers).
+--- Returns the raw CLI JSON payload as a string.
+--- @param name string Symbol name.
+--- @param opts table|nil `{ limit, offset, callees_top, callers_top, budget }`.
+--- @return string json
+function M.flow(name, opts)
+  vim.validate({
+    name = { name, 'string' },
+    opts = { opts, 'table', true },
+  })
+  return load_rust().scry_flow(name, opts)
+end
+
+--- Rank workspace files by how much they'd be affected if `name` changed.
+--- Score = direct*3 + imports*2 + transitive*1. Returns the raw CLI JSON.
+--- @param name string Symbol name.
+--- @param opts table|nil `{ limit, offset, hops, hub_guard }`.
+--- @return string json
+function M.impact(name, opts)
+  vim.validate({
+    name = { name, 'string' },
+    opts = { opts, 'table', true },
+  })
+  return load_rust().scry_impact(name, opts)
+end
+
 return M


### PR DESCRIPTION
## Summary

B7 from the Stream B plan: expose the `refs`, `flow`, and `impact` sub-commands through the MCP server, the Neovim Lua plugin, and the C FFI — **purely additively**. No existing tool / export / symbol is renamed or has its signature changed; the lock zones (fff-mcp 3 original tools, fff-nvim public Lua API, fff-c default ABI) stay byte-identical.

### MCP server (`crates/fff-mcp`)

Registers 3 new `#[tool]` methods on `FffServer`:

* `scry_refs(name, maxResults?, offset?)` — mirrors `scry refs --limit/--offset`.
* `scry_flow(name, maxResults?, offset?, calleesTop?, callersTop?, budget?)` — mirrors `scry flow --limit/--offset/--callees-top/--callers-top/--budget`.
* `scry_impact(name, maxResults?, offset?, hops?, hubGuard?)` — mirrors `scry impact --limit/--offset/--hops/--hub-guard`.

The 3 tools all shell out to the same scry binary via `std::env::current_exe()` and return the CLI's JSON payload as the tool response. New parameter shapes (`ScryRefsParams`, `ScryFlowParams`, `ScryImpactParams`) live in `crates/fff-mcp/src/scry.rs` alongside a `run_scry_subprocess` helper.

### Neovim Lua plugin (`crates/fff-nvim` + `lua/fff/scry.lua`)

Adds 3 Rust functions (`scry_refs`, `scry_flow`, `scry_impact`) inside the existing `#[cfg(feature = "scry")]` block in `crates/fff-nvim/src/lib.rs`. They share the same subprocess helper. Each returns the CLI's raw JSON as a string (so Lua callers can decide whether to decode with `vim.json.decode`).

The Lua wrapper `lua/fff/scry.lua` gets matching `M.refs`, `M.flow`, `M.impact` functions documented with luadoc. Existing `M.init` / `M.dispatch` / `M.symbol` / `M.grep` / `M.read` are unchanged.

### C FFI (`crates/fff-c`)

Behind the existing `FFF_SCRY` cfg/feature flag, adds 3 new `extern "C"` entrypoints in `crates/fff-c/src/scry_ffi.rs`:

* `fff_scry_refs(engine, name, limit, offset)`
* `fff_scry_flow(engine, name, limit, offset, callees_top, callers_top, budget)`
* `fff_scry_impact(engine, name, limit, offset, hops, hub_guard)`

All three return the existing `FffScryResponse` envelope and are freed via the existing `fff_free_scry_response`. The header `crates/fff-c/include/fff.h` is updated by hand (cbindgen-friendly shape, all 3 declarations guarded by `#if defined(FFF_SCRY)`).

The default C ABI is byte-identical to before — the new symbols only appear when consumers opt in by enabling the `scry` Cargo feature **and** defining `FFF_SCRY` on the C side.

### AGENT_GUIDE

* New "Lua / C bindings for scry tools" section documenting the 3 endpoints per surface.
* `mcp` section calls out the 3 new tools and their parameter conventions (`maxResults`, `calleesTop`, `callersTop`, `hubGuard`).

### Tests

* `crates/fff-mcp/src/scry.rs` — unit tests for `ScryRefsParams` / `ScryFlowParams` / `ScryImpactParams` JSON deserialization (minimal & full shapes, missing-name rejection).
* The underlying refs / flow / impact logic is already covered by the CLI tests merged in #20, #21, #22 (and pre-existing tests for `refs` / `flow`).
* Lua: end-to-end testing requires a real Neovim build with the `scry` Cargo feature — not run in CI yet; the wiring is purely a subprocess call to the already-tested CLI.
* C: header declarations are hand-maintained for now; default-build ABI is unchanged (the `scry` feature is off by default).

## Stacking

Builds on top of **#22 (B6)** because the wiring exposes the new `impact` sub-command. Merge order: B4 → B6 → B7. If #22 is rebased or its head moves, this PR's diff against `main` will need a rebase too.

## Review & Testing Checklist for Human

- [ ] Run `cargo build -p fff-c --features scry` — confirm `fff_scry_refs` / `fff_scry_flow` / `fff_scry_impact` symbols show up in the cdylib.
- [ ] Run `cargo build -p fff-mcp` then call `scry_refs` / `scry_flow` / `scry_impact` from an MCP client against this repo.
- [ ] Verify default builds (no `scry` feature) keep the C ABI byte-identical — only `fff_*` functions are exported.
- [ ] Spot-check that no existing MCP tool name / Lua export / C symbol was renamed or had its signature changed.

### Notes

With B7 merged, the full Stream B (B3 → B4 → B6 → B7) is complete.