### PR TITLE
test: add tmplate to typos ignore list for did-you-mean fuzzy test

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -15,6 +15,9 @@ thm = "thm"
 comparsion = "comparsion"
 modfiers = "modfiers"
 shcema = "shcema"
+# Intentional typo in `ffs symbol` did-you-mean fuzzy test to demonstrate
+# that "rendr_tmplate" resolves to "render_template".
+tmplate = "tmplate"
 # Intentional typo in `ffs find` fuzzy-fallback doc comment / tests to
 # demonstrate that "isntall.sh" resolves to "install.sh".
 isntall = "isntall"


### PR DESCRIPTION
## Summary

Fix `make lint` failing on `typos` check by allowlisting the intentional test typo `tmplate` (used in the `did_you_mean` fuzzy-match test that proves `"rendr_tmplate"` resolves to `"render_template"`).

Follows the same pattern as the existing test-only typo entries (`comparsion`, `modfiers`, `shcema`, `isntall`).

## Why

```
$ typos .
error: `tmplate` should be `template`
    ╭▸ ./crates/ffs-cli/src/commands/did_you_mean.rs:336:43
    │
336 │         let out = fuzzy_candidates("rendr_tmplate", &names, 2);
```

The string is required test data — the test explicitly verifies that the fuzzy fallback can recover `render_template` from this typo'd input. Changing the test string would defeat the test; allowlisting in `_typos.toml` is the correct fix.

## Verified

- `make lint` — passes (clippy, luacheck, stylua, biome, typos)
- `make format` — clean
- `make test` — all suites pass (Rust 600+, Lua 26 files, Bun 41, Node 25)
- Manual CLI sweep across all subcommands — works
- MCP server JSON-RPC sample — works

## Context on the other CI failure

The failing `Build CLI aarch64-pc-windows-msvc` job on the latest release run aborts right after the `setup-zig` cache hit with no compile error (`Post job cleanup` / `Terminate orphan process: pid (6736) (vctip)`). Sibling aarch64 Windows jobs on the same commit succeed. It looks like a runner-side abort, not a code issue, so no change is included for that here.