### PR TITLE
fix(install.ps1): allow empty PathScope for piped iex usage

### DIFF
--- a/doc/ffs.nvim.txt
+++ b/doc/ffs.nvim.txt
@@ -1,5 +1,5 @@
 *ffs.nvim.txt*
-                              For Neovim >= 0.10.0    Last change: 2026 May 19
+                              For Neovim >= 0.10.0    Last change: 2026 May 20
 
 ==============================================================================
 Table of Contents                                 *ffs.nvim-table-of-contents*

--- a/install.ps1
+++ b/install.ps1
@@ -48,7 +48,7 @@
 param(
     [string]$Version      = $env:FFS_VERSION,
     [string]$InstallDir   = $env:FFS_INSTALL_DIR,
-    [ValidateSet('User', 'Profile', 'None')]
+    [ValidateSet('User', 'Profile', 'None', '')]
     [string]$PathScope,
     [switch]$EasyMode,
     [switch]$Verify,


### PR DESCRIPTION
## Summary

When the install script is run via `irm ... | iex`, PowerShell initializes the `$PathScope` parameter as an empty string `""` (the default for `[string]`) **before** applying the `[ValidateSet('User', 'Profile', 'None')]` attribute. Since `""` is not in the allowed set, the attribute validation fails immediately with:

```
The attribute cannot be added because variable PathScope with value  would no longer be valid.
```

The fix adds `''` to the `ValidateSet`, allowing the empty default to pass validation. The existing fallback logic (lines 72-76) already handles the empty case by assigning a proper value (`User`), so behavior is unchanged for all other invocation methods.

## Review & Testing Checklist for Human

- [ ] Run `irm https://raw.githubusercontent.com/quangdang46/fast_file_search/devin/1779301585-fix-install-ps1-pathscope/install.ps1 | iex` on Windows PowerShell and confirm it no longer errors
- [ ] Run the script directly with explicit `-PathScope User` and confirm it still works

### Notes

One-line change: `[ValidateSet('User', 'Profile', 'None')]` → `[ValidateSet('User', 'Profile', 'None', '')]`