### PR TITLE
fix(core): normalize forward slashes in Windows path lookups

### DIFF
--- a/crates/ffs-core/src/file_picker.rs
+++ b/crates/ffs-core/src/file_picker.rs
@@ -228,7 +228,7 @@ impl FileSync {
         // canonicalize-then-strip so watcher events still land on the right
         // `FileItem`.
         let rel_path_owned: String = match path.strip_prefix(base_path) {
-            Ok(r) => r.to_string_lossy().into_owned(),
+            Ok(r) => normalize_relative_path(&r.to_string_lossy()).into_owned(),
             Err(_) => {
                 #[cfg(windows)]
                 {
@@ -1590,7 +1590,7 @@ impl FilePicker {
         if let Ok(stripped) = path.strip_prefix(&self.base_path)
             && let Some(s) = stripped.to_str()
         {
-            return Some(std::borrow::Cow::Borrowed(s));
+            return Some(normalize_relative_path(s));
         }
 
         #[cfg(windows)]
@@ -1602,6 +1602,30 @@ impl FilePicker {
         #[cfg(not(windows))]
         None
     }
+}
+
+/// Normalize relative-path separators so byte-wise comparisons against
+/// arena-stored paths are stable on Windows.
+///
+/// `pathdiff::diff_paths` (used during scan) builds a `PathBuf` whose
+/// segments are joined with `MAIN_SEPARATOR` (`\\`), but lookups go through
+/// `Path::strip_prefix` which returns a sub-slice of the original input —
+/// so callers that constructed the path via `base.join("a/b/c")` end up
+/// with `/` in the lookup key and never match the stored `a\\b\\c`.
+#[cfg(windows)]
+#[inline]
+fn normalize_relative_path(s: &str) -> std::borrow::Cow<'_, str> {
+    if s.contains('/') {
+        std::borrow::Cow::Owned(s.replace('/', "\\"))
+    } else {
+        std::borrow::Cow::Borrowed(s)
+    }
+}
+
+#[cfg(not(windows))]
+#[inline]
+fn normalize_relative_path(s: &str) -> std::borrow::Cow<'_, str> {
+    std::borrow::Cow::Borrowed(s)
 }
 
 /// Resolve a possibly-short-name Windows path to the picker's canonical base.

--- a/doc/ffs.nvim.txt
+++ b/doc/ffs.nvim.txt
@@ -1,5 +1,5 @@
 *ffs.nvim.txt*
-                              For Neovim >= 0.10.0    Last change: 2026 May 20
+                              For Neovim >= 0.10.0    Last change: 2026 May 21
 
 ==============================================================================
 Table of Contents                                 *ffs.nvim-table-of-contents*


### PR DESCRIPTION
## Summary

Fix a Windows-specific path-separator bug in `FilePicker` that caused `remove_file_by_path` / `get_file_by_path` / `handle_create_or_modify` to silently fall through whenever the caller's path contained forward slashes.

### Root cause

`FileItem::new` / `new_from_walk` build the arena-stored relative path with `pathdiff::diff_paths(path, base_path)`. On Windows, `diff_paths` produces a fresh `PathBuf` joined with `MAIN_SEPARATOR` (`\`), so storage keys look like `src\core\repo_0000.rs`.

Lookups, however, run `Path::strip_prefix(base_path)` and `to_string_lossy()`. `strip_prefix` returns a sub-slice of the input path, preserving whatever separator the caller used. Any caller that passed a path built via `base.join("src/core/repo_0000.rs")` ended up with a lookup key like `src/core/repo_0000.rs` that never byte-matches the stored `src\core\repo_0000.rs`.

Verified locally on Windows with a tiny repro:

```
PathBuf joined           = "C:\...\src/core/repo_0000.rs"   <- keeps `/` from input
strip_prefix(base)       = "src/core/repo_0000.rs"          <- lookup key (forward slash)
pathdiff::diff_paths     = "src\core\repo_0000.rs"          <- storage key (backslash)
```

### Symptoms

On Windows, `cargo test -p ffs-search --no-default-features --test bigram_overlay_coherence_test` fails 7 of 16 cases - all of them call `remove_file_by_path(&base.join("src/core/...rs"))` and assert that the file is gone, but the lookup silently fails so the file is never tombstoned and subsequent grep checks find the "deleted" content:

- bigram_overlay_coherence_stress_base_edits_and_deletes
- bigram_overlay_coherence_long_session_incremental_edits
- bigram_overlay_coherence_mixed_tombstones_and_overflow
- bigram_overlay_coherence_full_lifecycle_seed_edit_commit_rescan_edit
- bigram_overlay_coherence_full_stress_loop_with_overflow
- bigram_overlay_coherence_fuzzy_and_grep_combined
- bigram_overlay_coherence_resurrect_tombstoned_file

The same code path is exercised by `update_single_file_frecency`, `get_file_by_path`, `get_mut_file_by_path`, and `handle_create_or_modify`, so any Windows caller passing `/` would silently no-op. The background watcher path was unaffected because `notify` emits backslash-only paths.

### Fix

Add a `normalize_relative_path` helper in `crates/ffs-core/src/file_picker.rs` that rewrites `/` to `\` on Windows (and is a `Cow::Borrowed` no-op on other platforms). Call it after `strip_prefix` in both `FileSync::find_file_index` and `FilePicker::to_relative_path` so lookups always match the arena's storage representation. The `canonical_relative_path` Windows fallback already returns backslash-only strings (via `dunce::canonicalize`), so it didn't need changes.

The fix is fully `#[cfg(windows)]`-gated; Linux and macOS behavior is bit-identical (Cow::Borrowed wrapping a `&str` is a noop).

### Verification on Windows

After applying the fix, on `windows-server-2022` with Rust `1.95.0` and MSVC Build Tools 2022:

- `cargo test --workspace --no-default-features --exclude ffs-nvim --exclude ffs-c` -> **all 30 test binaries pass**, including the previously-failing 16-case `bigram_overlay_coherence_test`.
- `cargo fmt --all -- --check` -> clean.
- Full smoke test of the built `ffs.exe` against this very repo across 33 subcommands (index, find, glob, grep, read, outline, symbol, callers, callees, refs, flow, siblings, deps, impact, dispatch, map, overview, guide, completions, mcp) -> all 33 exit `0`.

## Review & Testing Checklist for Human

Risk level: **yellow** - small surface-area change, gated to Windows, but it touches a hot lookup path used by every file-modification event.

- [ ] Confirm the new `normalize_relative_path` helper is the only Windows-aware string-normalization site for relative paths (i.e., no other call site bypasses it by reading from `strip_prefix` and comparing directly against arena strings).
- [ ] Verify that the existing Linux/macOS CI green stays green - the non-Windows path is a `Cow::Borrowed` and should be a noop.
- [ ] On Windows CI, confirm `bigram_overlay_coherence_test` now goes from 9/16 to 16/16 passing.
- [ ] Spot-check that callers expecting `to_relative_path` to return a borrowed slice still compile - the return type widened from "always-Borrowed" to "Borrowed-or-Owned Cow", but everything downstream already accepted `Cow`.

### Notes

- Two pre-existing `clippy::needless_return` warnings on Windows (in `file_picker.rs:1599` and `path_utils.rs:29`, both inside `#[cfg(windows)]` blocks) were intentionally left alone to keep the diff scoped to the actual bug; happy to fold those in if you'd prefer.
- The Devin git proxy returned 403 for pushes from this Windows VM, so this branch was pushed via a one-time user-provided PAT (which the user will revoke). Not relevant to the change itself, just FYI in case future Windows Devin sessions on this repo run into the same wall.
