### PR TITLE
fix(install.ps1): suppress NativeCommandError that aborts MCP registration

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -82,6 +82,19 @@ function Write-Info    { param($m) Write-Host "[$BinaryName] $m" }
 function Write-Success { param($m) Write-Host "[OK] $m" -ForegroundColor Green }
 function Write-Warn    { param($m) Write-Host "[$BinaryName] WARN: $m" -ForegroundColor Yellow }
 
+# Run a native command, swallow all output, and prevent PowerShell 5.1's
+# `NativeCommandError` from terminating the script under `Stop`. Returns
+# `$LASTEXITCODE`. `2>$null` alone is not enough: PS 5.1 still surfaces a
+# `RemoteException` (red text) and, with `$ErrorActionPreference = 'Stop'`,
+# aborts the script the first time a native exe writes to stderr.
+function Invoke-Quiet {
+    param([Parameter(Mandatory)][scriptblock]$Block)
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = 'SilentlyContinue'
+    try { & $Block 2>&1 | Out-Null } finally { $ErrorActionPreference = $prev }
+    return $LASTEXITCODE
+}
+
 # === Platform detection ===
 function Get-Target {
     $arch = (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment').PROCESSOR_ARCHITECTURE
@@ -260,12 +273,12 @@ function Register-McpClaude {
         Write-Info "[mcp dry-run] claude mcp add -s user $McpName -- $cmd mcp"
         return
     }
-    & claude mcp remove -s user $McpName 2>$null
-    try {
-        & claude mcp add -s user $McpName -- $cmd mcp 2>$null
+    [void](Invoke-Quiet { & claude mcp remove -s user $McpName })
+    $rc = Invoke-Quiet { & claude mcp add -s user $McpName -- $cmd mcp }
+    if ($rc -eq 0) {
         Write-Success "[mcp] registered with Claude Code"
-    } catch {
-        Write-Warn "claude mcp add failed"
+    } else {
+        Write-Warn "claude mcp add failed (exit $rc)"
     }
 }
 
@@ -277,12 +290,12 @@ function Register-McpCodex {
         Write-Info "[mcp dry-run] codex mcp add $McpName -- $cmd mcp"
         return
     }
-    & codex mcp remove $McpName 2>$null
-    try {
-        & codex mcp add $McpName -- $cmd mcp 2>$null
+    [void](Invoke-Quiet { & codex mcp remove $McpName })
+    $rc = Invoke-Quiet { & codex mcp add $McpName -- $cmd mcp }
+    if ($rc -eq 0) {
         Write-Success "[mcp] registered with Codex"
-    } catch {
-        Write-Warn "codex mcp add failed"
+    } else {
+        Write-Warn "codex mcp add failed (exit $rc)"
     }
 }
 
@@ -372,12 +385,12 @@ function Invoke-McpUninstall {
     Write-Info "Removing '$McpName' from MCP providers..."
     # Claude
     if (Get-Command claude -ErrorAction SilentlyContinue) {
-        & claude mcp remove -s user $McpName 2>$null
+        [void](Invoke-Quiet { & claude mcp remove -s user $McpName })
         Write-Success "[mcp] removed $McpName from Claude Code"
     }
     # Codex
     if (Get-Command codex -ErrorAction SilentlyContinue) {
-        & codex mcp remove $McpName 2>$null
+        [void](Invoke-Quiet { & codex mcp remove $McpName })
         Write-Success "[mcp] removed $McpName from Codex"
     }
     # Cursor


### PR DESCRIPTION
## Summary

Stop `irm install.ps1 | iex` from bailing out at the first MCP provider on a fresh Windows install.

### What the user sees today

```
PS C:\Users\ADMIN> irm https://raw.githubusercontent.com/quangdang46/fast_file_search/main/install.ps1 | iex
[ffs] Detected platform: x86_64-pc-windows-msvc
[ffs] Latest version: v0.1.2
[ffs] Downloading ffs-x86_64-pc-windows-msvc.exe...
[ffs] Checksum verified.
[OK] Installed C:\Users\ADMIN\AppData\Local\ffs\bin\ffs.exe
[OK] Added C:\Users\ADMIN\AppData\Local\ffs\bin to user PATH.
[ffs] Registering 'ffs' with MCP providers (claude, codex, cursor, cline, opencode, continue)...
claude.exe : No user-scoped MCP server found with name: ffs
At line:263 char:5
+     & claude mcp remove -s user $McpName 2>$null
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (No user-scoped ... with name: ffs:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
PS C:\Users\ADMIN>
```

The script aborts - codex, cursor, cline, opencode, and continue are silently skipped.

### Root cause

`install.ps1` declares `$ErrorActionPreference = 'Stop'` at the top. In Windows PowerShell 5.1, every stderr line from a native exe becomes a `RemoteException` `ErrorRecord`, and under `Stop` that record is treated as terminating. The first call

```powershell
& claude mcp remove -s user $McpName 2>$null
```

aborts the pipeline because the `claude` CLI writes `No user-scoped MCP server found with name: ffs` to stderr on a fresh install. `2>$null` redirects the stream but does **not** suppress the `ErrorRecord`. Reproduced locally on PS 5.1 with a tiny `cmd.exe` shim:

```
PS> $ErrorActionPreference = 'Stop'
PS> & cmd /c 'echo bad 1>&2 & exit 1' 2>$null
cmd.exe : bad
At line:1 char:1
+ & cmd /c 'echo bad 1>&2 & exit 1' 2>$null
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (bad :String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
```

The `try`/`catch` blocks that already wrap each `mcp add` don't help here because the failing `mcp remove` sits **outside** the `try` block.

### Fix

Add an `Invoke-Quiet` helper that temporarily drops `$ErrorActionPreference` to `SilentlyContinue` and merges all streams to `Out-Null`, returning `$LASTEXITCODE`. Route every `claude` / `codex` MCP CLI call through it and drop the now-unnecessary `try`/`catch` in favor of an explicit exit-code check.

```powershell
function Invoke-Quiet {
    param([Parameter(Mandatory)][scriptblock]$Block)
    $prev = $ErrorActionPreference
    $ErrorActionPreference = 'SilentlyContinue'
    try { & $Block 2>&1 | Out-Null } finally { $ErrorActionPreference = $prev }
    return $LASTEXITCODE
}
```

Only the `claude` / `codex` flows are touched. The JSON/YAML providers (cursor, cline, opencode, continue) never invoke native binaries and weren't affected.

### Verification on Windows PowerShell 5.1

Reproduced with shims at `C:\Users\Administrator\fake-mcp-shim\{claude,codex}.cmd` that echo a "No MCP server found" line to stderr and exit `1` on `remove`:

```
PS> $env:Path = "C:\Users\Administrator\fake-mcp-shim;" + $env:Path
PS> powershell -ExecutionPolicy Bypass -NoProfile -File install.ps1 -McpOnly -McpProviders 'claude,codex'
[ffs] Skipping binary install (-McpOnly)
[ffs] Registering 'ffs' with MCP providers (claude, codex)...
[OK] [mcp] registered with Claude Code
[OK] [mcp] registered with Codex
[OK] ffs MCP registration complete.
```

```
PS> powershell -ExecutionPolicy Bypass -NoProfile -File install.ps1 -McpUninstall
[ffs] Removing 'ffs' from MCP providers...
[OK] [mcp] removed ffs from Claude Code
[OK] [mcp] removed ffs from Codex
```

No red `NativeCommandError` block, script runs to completion, every provider gets a chance.

## Review & Testing Checklist for Human

Risk level: **yellow** - small, but it's the install path that every new Windows user touches first.

- [ ] On a real Windows machine without `ffs` previously registered, run `irm https://raw.githubusercontent.com/quangdang46/fast_file_search/main/install.ps1 | iex` and confirm no red error block, and that all detected MCP providers (claude, codex, cursor, cline, opencode, continue) are processed.
- [ ] Re-run the same `irm ... | iex` after `ffs` is already registered with Claude Code - the `remove`-then-`add` sequence should still produce `[OK] [mcp] registered with Claude Code`.
- [ ] Run `.\install.ps1 -McpUninstall` and confirm Claude Code / Codex no longer list `ffs` (e.g. `claude mcp list` shows it gone).
- [ ] Sanity-check that Cursor / Cline / OpenCode / Continue registration (the JSON/YAML paths, untouched in this PR) still works.

### Notes

- The `Invoke-Quiet` helper is intentionally narrow - it only wraps the native-CLI calls. If we ever add more `& <exe> ...` invocations elsewhere in the script, they should use this helper to stay safe under `Stop`.
- This is a follow-up to #33 (Windows path separator fix); same Windows test box, no overlap.
