### PR TITLE
fix(install.ps1): defend against `not a valid application` failures on Windows

### DIFF
--- a/doc/ffs.nvim.txt
+++ b/doc/ffs.nvim.txt
@@ -1,5 +1,5 @@
 *ffs.nvim.txt*
-                              For Neovim >= 0.10.0    Last change: 2026 May 21
+                              For Neovim >= 0.10.0    Last change: 2026 May 22
 
 ==============================================================================
 Table of Contents                                 *ffs.nvim-table-of-contents*

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 <#
 .SYNOPSIS
     ffs installer for Windows — downloads the right binary from GitHub Releases
@@ -171,12 +171,14 @@ function Add-ToUserPath {
     param([string]$Dir)
     $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
     if (-not $userPath) { $userPath = '' }
-    $entries = $userPath -split ';' | Where-Object { $_ -ne '' }
-    if ($entries -notcontains $Dir -and $entries -notcontains $Dir.TrimEnd('\')) {
-        $newPath = (@($entries + $Dir) -join ';')
-        [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
-        Write-Success "Added $Dir to user PATH."
-    }
+    $entries = $userPath -split ';' | Where-Object { $_ -ne '' -and $_ -ne $Dir -and $_ -ne $Dir.TrimEnd('\') }
+    # Prepend rather than append so the freshly installed binary always wins
+    # PATH resolution. Appending leaves us shadowed by any stale `ffs.exe` (or
+    # zero-byte WindowsApps stub) earlier on PATH, which is the classic cause
+    # of "not a valid application for this OS platform" right after install.
+    $newPath = (@(@($Dir) + $entries) -join ';')
+    [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+    Write-Success "Added $Dir to user PATH (prepended)."
 }
 
 function Add-ToProfilePath {
@@ -200,7 +202,10 @@ function Set-PathPersistence {
         'Profile' { Add-ToProfilePath $Dir }
         'None'    { Write-Info "Skipping PATH persistence (-PathScope None)." }
     }
-    if (-not (Test-OnPath $Dir)) { $env:PATH = "$env:PATH;$Dir" }
+    # Mirror the prepend in the *current* session so the rest of this script
+    # (and the user's next command, if they don't open a new shell) resolves
+    # `ffs` to the binary we just wrote.
+    if (-not (Test-OnPath $Dir)) { $env:PATH = "$Dir;$env:PATH" }
 }
 
 # === Uninstall ===
@@ -454,22 +459,82 @@ function Main {
                 Write-Warn "No sha256 sidecar or verification failed - skipping checksum"
             }
 
-            # Install
+            # Install. Atomic-ish: stage as `<dest>.tmp.<pid>` *inside* the
+            # destination directory (same volume, so Move-Item is a rename,
+            # never a copy-and-delete that an AV scanner could intercept
+            # mid-write), then atomically rename onto the final path.
             New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
             $dest = Join-Path $InstallDir "$BinaryName.exe"
-            Move-Item -Force -Path $tmpFile -Destination $dest
+            $stage = "$dest.tmp.$PID"
+            if (Test-Path $stage) { Remove-Item -Force $stage }
+            Copy-Item -LiteralPath $tmpFile -Destination $stage -Force
+            try {
+                Move-Item -LiteralPath $stage -Destination $dest -Force
+            } catch {
+                Remove-Item -LiteralPath $stage -Force -ErrorAction SilentlyContinue
+                throw
+            }
+            # Strip the Zone.Identifier ADS so SmartScreen / WDAC doesn't
+            # block downstream invocations with a generic "not a valid
+            # application for this OS platform" error.
+            try { Unblock-File -LiteralPath $dest -ErrorAction SilentlyContinue } catch {}
             Write-Success "Installed $dest"
+
+            # Fail loudly if Defender / an EDR has already replaced the
+            # file with a quarantine stub. The published Windows asset is
+            # ~35 MB; anything dramatically smaller is almost certainly a
+            # stub or a truncated download.
+            $installed = Get-Item -LiteralPath $dest
+            if ($installed.Length -lt 1MB) {
+                throw "Installed $dest is only $($installed.Length) bytes - this is almost certainly an antivirus quarantine stub. Check Get-MpThreatDetection or your EDR console, then add an exclusion for $InstallDir and re-run the installer."
+            }
+            # Quick PE-header sanity check: byte 0/1 must be 'MZ' (0x4D 0x5A).
+            $head = [System.IO.File]::ReadAllBytes($dest)[0..1]
+            if (-not ($head[0] -eq 0x4D -and $head[1] -eq 0x5A)) {
+                throw "Installed $dest does not have a valid PE header (first bytes: $('{0:X2}{1:X2}' -f $head[0], $head[1])). The download was corrupted or modified post-install."
+            }
         } finally {
             Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
         }
 
         Set-PathPersistence -Dir $InstallDir -Scope $PathScope
 
-        if ($Verify -or $EasyMode) {
-            Write-Info "Running self-test..."
-            & $dest --version
-            if ($LASTEXITCODE -ne 0) { throw "Self-test failed" }
+        # Always run a self-test. The cost is a single `--version` invocation;
+        # the benefit is that we catch the "installed but won't run" failure
+        # mode (AV quarantine, WindowsApps stub shadowing, wrong-arch binary,
+        # Mark-of-the-Web blocking) *before* the script exits and the user is
+        # left staring at a confusing error from their next prompt.
+        Write-Info "Running self-test..."
+        $selfTest = & $dest --version 2>&1
+        if ($LASTEXITCODE -ne 0 -or -not $selfTest) {
+            Write-Host ""
+            Write-Host "Self-test FAILED for $dest" -ForegroundColor Red
+            Write-Host "  Output: $selfTest"
+            try {
+                $f = Get-Item -LiteralPath $dest
+                $h = [System.IO.File]::ReadAllBytes($dest)[0..1]
+                Write-Host "  File size: $($f.Length) bytes"
+                Write-Host "  PE magic:  $('{0:X2}{1:X2}' -f $h[0], $h[1]) (must be 4D5A)"
+                Write-Host "  SHA256:    $((Get-FileHash -LiteralPath $dest -Algorithm SHA256).Hash)"
+            } catch {}
+            # Show whether some other ffs.exe is shadowing ours on PATH.
+            Write-Host "  All ffs in PATH:"
+            try {
+                Get-Command $BinaryName -All -ErrorAction SilentlyContinue |
+                    ForEach-Object { Write-Host "    $($_.Source)" }
+            } catch {}
+            Write-Host ""
+            Write-Host "Likely causes:"
+            Write-Host "  1. Antivirus/EDR quarantined the binary (Defender, CrowdStrike, etc)."
+            Write-Host "     Run:  Get-MpThreatDetection | Where-Object Resources -match 'ffs'"
+            Write-Host "     Then add an exclusion for $InstallDir and re-run."
+            Write-Host "  2. Another ffs.exe earlier on PATH is shadowing ours."
+            Write-Host "     Run:  where.exe ffs"
+            Write-Host "  3. Mark-of-the-Web is blocking execution."
+            Write-Host "     Run:  Unblock-File '$dest'"
+            throw "Self-test failed - see diagnostics above."
         }
+        Write-Success "Self-test passed: $($selfTest | Select-Object -First 1)"
     } else {
         Write-Info "Skipping binary install (-McpOnly)"
     }
@@ -484,9 +549,8 @@ function Main {
         $dest = Join-Path $InstallDir "$BinaryName.exe"
         Write-Host ""
         Write-Success "ffs installed to $dest"
-        try { & $dest --version 2>$null } catch {}
         Write-Host ""
-        Write-Host "Quick start:"
+        Write-Host "Quick start (open a new PowerShell window for PATH changes):"
         Write-Host "  ffs --help"
         Write-Host "  ffs index           # one-time warm-up"
         Write-Host "  ffs find <query>"


### PR DESCRIPTION
## Summary

Fixes the post-install failure mode reported on Windows where `install.ps1` finishes successfully and the in-script self-test prints the correct version, but the user's *next* invocation of `ffs` from the prompt is rejected with:

```
Program 'ffs.exe' failed to run: The specified executable is not a valid application for this OS platform.
```

That's `ERROR_BAD_EXE_FORMAT` (193). I verified the published `ffs-x86_64-pc-windows-msvc.exe` from the `v0.1.3` release is a valid AMD64 PE (`MZ` magic, `PE` signature, machine `0x8664`, 35 MB), so the binary itself isn't the problem. Something between install completion and the user's next prompt is causing the loader to reject *some* `ffs.exe` — either ours (modified post-write) or a different one resolved through PATH.

This PR closes the three classes of root cause in one shot and adds a mandatory diagnostic dump so the next failure (if any) reports actionable information.

### 1. PATH shadowing — the most likely culprit

`Add-ToUserPath` and `Set-PathPersistence` both **appended** `$InstallDir` to PATH. That leaves us last in resolution order, behind any stale `ffs.exe` (a previous build, a `cargo install` leftover, a zero-byte `%LOCALAPPDATA%\Microsoft\WindowsApps` reservation stub, etc.) already on PATH.

When the script invokes `& $dest` (absolute path) the self-test passes. When the user types `ffs` (PATH lookup) the loader picks up the shadowed file and chokes on its PE header.

Now we **prepend** in both the persistent user PATH and the current `$env:PATH`, and drop any duplicate entries for `$InstallDir` (with or without trailing slash) before the prepend.

### 2. Mid-write interception by AV / EDR

`Move-Item -Force` from `%TEMP%\<random>\ffs-*.exe` to `$InstallDir\ffs.exe` may cross volumes — `%TEMP%` and `%LOCALAPPDATA%` can live on different physical disks on multi-drive setups. A cross-volume move downgrades to copy-then-delete, which an AV scanner can interrupt mid-write, leaving a partial file on disk.

Now we `Copy-Item` into `<dest>.tmp.<pid>` *inside* the destination directory (guaranteed same volume) and then `Move-Item` onto the final path — a same-volume rename, atomic from the filesystem's perspective.

### 3. Mark-of-the-Web blocking

The Zone.Identifier ADS Windows attaches to downloaded files can trigger SmartScreen / WDAC blocking on subsequent invocations, and the error surface depending on policy includes generic "not a valid application for this OS platform" messages. `Unblock-File -LiteralPath $dest` strips that ADS right after install.

### Mandatory self-test + diagnostics

The self-test (`& $dest --version`) was previously gated on `-Verify` or `-EasyMode`. The summary section's `& $dest --version 2>$null` was always run but discarded the exit code, so install was reported as successful even when the binary couldn't execute.

Now the self-test is mandatory. On failure it dumps:

- Installed file size (catches AV quarantine stubs — anything < 1 MB is almost certainly a stub).
- PE magic bytes (must be `4D5A`).
- SHA-256 of the file on disk.
- Every `ffs.exe` resolvable from PATH (catches shadowing).
- Prioritised list of likely causes with copy-pasteable recovery commands.

A size + PE-magic sanity check also runs immediately after the install completes, so we fail loudly on AV quarantine stubs before the script returns success.

## Verification

Local on Windows PS 5.1:
- `[System.Management.Automation.Language.Parser]::ParseInput(...)` returns 0 errors against the modified file.
- File saved with a UTF-8 BOM so `irm -OutFile install.ps1; .\install.ps1` works on PS 5.1 (BOM-less UTF-8 with the existing em-dash in the doc-comment block trips PS 5.1's default-encoding parse).

Verified the upstream binary directly:

```
URL:    https://github.com/quangdang46/fast_file_search/releases/download/v0.1.3/ffs-x86_64-pc-windows-msvc.exe
Size:   35857408 bytes
SHA256: 44299AFCE93F11533ACCAEFF7E6CD68DB7B4C8A4C425E255E2689C39390AC05F
MZ:     4D5A
PE:     50450000
Mach:   8664 (AMD64)
```

The published asset is fine — the post-install environment was the issue.

## Review & Testing Checklist for Human

- [ ] Run `irm https://raw.githubusercontent.com/quangdang46/fast_file_search/devin/1779440979-windows-install-fix/install.ps1 | iex` on the failing host. The mandatory self-test should now either pass (and the next `ffs` invocation in the same shell works because of the in-session PATH prepend) or fail loudly with the diagnostic dump pointing at which of the three root causes is actually in play.
- [ ] If the self-test still fails, run the commands the script prints (`where.exe ffs`, `Get-MpThreatDetection`, `Unblock-File`) and share the output — we'll know exactly which case we're in.
- [ ] Run `-Uninstall` and confirm `$InstallDir` is removed from user PATH cleanly (no leftover duplicates from the new prepend path).
- [ ] Test on a host that has another `ffs.exe` already on PATH (e.g. `cargo install`'d into `~\.cargo\bin`) — the prepend should make `ffs` resolve to our install dir.

### Notes

- The `Add-ToUserPath` change moves us from append → prepend. If you'd rather keep append for some reason (e.g. user-installed cargo binaries should still win over the release build), say the word and I'll gate prepend behind a `-PrependPath` switch with append as the default. My recommendation is prepend — it's what rustup, pyenv, fnm, and most Windows installers do.
- I did not touch the (large, complex) `release.yaml` — the Windows asset it produces is a valid PE. If you'd like to follow up by switching Windows packaging to `.zip + .sha256` (matches `linehash` / `openproxy` and lets `Expand-Archive` strip the Zone.Identifier ADS for free), I'm happy to open a separate PR.
- The user-reported sequence ran with no flags, so the bug was reproducible in the default install path — these fixes are unconditional, not gated on a new flag.
