### PR TITLE
fix(install.ps1): remove UTF-8 BOM that breaks irm | iex piping

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Version 5.1
+#Requires -Version 5.1
 <#
 .SYNOPSIS
     ffs installer for Windows — downloads the right binary from GitHub Releases


### PR DESCRIPTION
Removes UTF-8 BOM from install.ps1 that causes irm | iex to fail with BOM#Requires error.