### PR TITLE
feat(mention): ship Phases B/C/D (resolve, surfaces, extensibility)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,9 +692,11 @@ dependencies = [
  "ffs-search",
  "ffs-symbol",
  "git2",
+ "ignore",
  "mimalloc",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
 ]
 
@@ -770,6 +772,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/crates/ffs-c/Cargo.toml
+++ b/crates/ffs-c/Cargo.toml
@@ -19,6 +19,7 @@ zlob = ["ffs/zlob"]
 mimalloc.workspace = true
 tracing.workspace = true
 git2.workspace = true
+ignore = { workspace = true }
 
 ffs = { package = "ffs-search", path = "../ffs-core", version = "0.1.3" }
 ffs-query-parser = { path = "../ffs-query-parser", version = "0.1.3" }
@@ -27,4 +28,7 @@ ffs-budget = { workspace = true }
 ffs-symbol = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[dev-dependencies]
+tempfile = { workspace = true }
 

--- a/crates/ffs-c/include/ffs.h
+++ b/crates/ffs-c/include/ffs.h
@@ -849,6 +849,39 @@ const struct FfsScore *ffs_mixed_search_result_get_score(const struct FfsMixedSe
                                                          uint32_t index);
 
 /**
+ * Resolve a @-mention-style query and return a JSON-encoded
+ * `Vec<ResolvedMention>` in `FfsResult.handle` (free with `ffs_free_string`).
+ *
+ * The input is split on whitespace; each non-empty token becomes a
+ * substring candidate query against the file picker's `base_path`. Every
+ * match is then handed to the Phase B resolver which reads, classifies,
+ * filters, and truncates each path to fit the caller's token budget.
+ *
+ * `options_json` is a JSON object with optional fields. Forward-compatible:
+ * unknown keys are ignored. Currently recognized fields:
+ *   * `"max_tokens"`: `uint32` — body budget per mention (default 50000).
+ *   * `"line_range"`: `[uint32, uint32]` 1-based inclusive slice, applied
+ *     before smart_truncate (default: none).
+ *   * `"filter_level"`: `"none" | "minimal" | "aggressive"` (default
+ *     `"minimal"`).
+ *
+ * `cursor` is reserved for future Phase D streaming; today it is ignored.
+ *
+ * The returned `FfsResult.handle` is a heap-allocated C string (JSON array
+ * of `ResolvedMention`). Free it with `ffs_free_string`. On failure
+ * `success` is false and `error` carries the message.
+ *
+ * ## Safety
+ * * `ffs_handle` must be a valid instance pointer from `ffs_create_instance`.
+ * * `input` and `options_json` must be valid null-terminated UTF-8 strings
+ *   or NULL (NULL/empty `options_json` uses the defaults).
+ */
+struct FfsResult *ffs_mention_search_json(void *ffs_handle,
+                                          const char *input,
+                                          uint32_t cursor,
+                                          const char *options_json);
+
+/**
  * Returns the relative path of a file item (e.g. `"src/main.rs"`).
  *
  * Returns null if `item` is null. The returned pointer is valid for the

--- a/crates/ffs-c/src/lib.rs
+++ b/crates/ffs-c/src/lib.rs
@@ -42,6 +42,7 @@ use ffs::frecency::FrecencyTracker;
 use ffs::query_tracker::QueryTracker;
 use ffs::{DbHealthChecker, FfsMode, FuzzySearchOptions, PaginationArgs, QueryParser};
 use ffs::{SharedFilePicker, SharedFrecency};
+use ffs_engine::mention::{resolve_mentions, ResolveOptions};
 
 /// Opaque ffs_handle holding all per-instance state.
 ///
@@ -1574,4 +1575,294 @@ pub unsafe extern "C" fn ffs_mixed_search_result_get_score(
         return std::ptr::null();
     }
     unsafe { result.scores.add(index as usize) }
+}
+
+// ---------------------------------------------------------------------------
+// Phase C — @-mention JSON surface
+// ---------------------------------------------------------------------------
+
+/// Resolve a @-mention-style query and return a JSON-encoded
+/// `Vec<ResolvedMention>` in `FfsResult.handle` (free with `ffs_free_string`).
+///
+/// The input is split on whitespace; each non-empty token becomes a
+/// substring candidate query against the file picker's `base_path`. Every
+/// match is then handed to the Phase B resolver (`ffs_engine::mention`)
+/// which reads, classifies, filters, and truncates each path to fit the
+/// caller's token budget.
+///
+/// `options_json` is a JSON object with optional fields. Forward-compatible:
+/// unknown keys are ignored. Currently recognized fields:
+///   * `"max_tokens"`: `u32` — body budget per mention (default 50_000).
+///   * `"line_range"`: `[u32, u32]` 1-based inclusive slice, applied before
+///     `smart_truncate` so the line range is honored even when the file is
+///     large (default: none).
+///   * `"filter_level"`: `"none" | "minimal" | "aggressive"` (default
+///     `"minimal"`).
+///
+/// `cursor` is reserved for future Phase D streaming; today it is ignored.
+///
+/// The returned `FfsResult.handle` is a heap-allocated C string (JSON array
+/// of `ResolvedMention`). Free it with `ffs_free_string`. On failure
+/// `success` is false and `error` carries the message.
+///
+/// ## Safety
+/// * `ffs_handle` must be a valid instance pointer from `ffs_create_instance`.
+/// * `input` and `options_json` must be valid null-terminated UTF-8 strings
+///   or NULL (NULL/empty `options_json` uses the defaults).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ffs_mention_search_json(
+    ffs_handle: *mut c_void,
+    input: *const c_char,
+    _cursor: u32,
+    options_json: *const c_char,
+) -> *mut FfsResult {
+    // Validate instance first so a bad handle never gets paired with a
+    // bogus success payload.
+    let inst = match unsafe { instance_ref(ffs_handle) } {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+
+    let input_str = match unsafe { cstr_to_str(input) } {
+        Some(s) => s,
+        None => return FfsResult::err("input is null or invalid UTF-8"),
+    };
+
+    // Parse options (forward-compatible: ignore unknown fields).
+    #[derive(Default, serde::Deserialize)]
+    struct RawOptions {
+        max_tokens: Option<u32>,
+        line_range: Option<(u32, u32)>,
+        filter_level: Option<String>,
+    }
+    let raw: RawOptions = match unsafe { optional_cstr(options_json) } {
+        Some(s) => match serde_json::from_str(s) {
+            Ok(v) => v,
+            Err(e) => return FfsResult::err(&format!("options_json parse error: {e}")),
+        },
+        None => RawOptions::default(),
+    };
+    let max_tokens = raw.max_tokens.unwrap_or(50_000);
+    let filter_level = match raw.filter_level.as_deref() {
+        Some("none") => ffs_budget::FilterLevel::None,
+        Some("aggressive") => ffs_budget::FilterLevel::Aggressive,
+        _ => ffs_budget::FilterLevel::Minimal,
+    };
+    let line_range = raw.line_range;
+    let opts = ResolveOptions {
+        max_tokens,
+        filter_level,
+        line_range,
+    };
+
+    // Candidate selection: substring walk of base_path. We could route
+    // through `picker.fuzzy_search` but that would couple this surface to
+    // the indexed DB and the AI-mode parse grammar; a plain walk is
+    // honest about the trade-off (no fuzzy ranking, but always works even
+    // when the index is cold or `watch=false`).
+    let base_path = {
+        let guard = match inst.picker.read() {
+            Ok(g) => g,
+            Err(e) => return FfsResult::err(&format!("picker lock: {e}")),
+        };
+        match guard.as_ref() {
+            Some(p) => p.base_path().to_path_buf(),
+            None => return FfsResult::err("File picker not initialized"),
+        }
+    };
+
+    let tokens: Vec<&str> = input_str
+        .split_whitespace()
+        .filter(|t| !t.is_empty())
+        .collect();
+    if tokens.is_empty() {
+        // Nothing to resolve. Return an empty array so callers always get
+        // a valid JSON document.
+        return FfsResult::ok_string("[]");
+    }
+
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    for entry in walk_files_simple(&base_path) {
+        let Some(s) = entry.to_str() else { continue };
+        if tokens.iter().any(|t| s.contains(t)) && seen.insert(s.to_string()) {
+            candidates.push(entry);
+        }
+    }
+
+    let resolved = resolve_mentions(&candidates, &opts);
+    match serde_json::to_string(&resolved) {
+        Ok(json) => FfsResult::ok_string(&json),
+        Err(e) => FfsResult::err(&format!("serialize ResolvedMention: {e}")),
+    }
+}
+
+/// Single-threaded recursive directory walk. The mention surface does not
+/// need the parallel `ignore::WalkBuilder` — the candidate list is small
+/// (substring-filtered) and the resolver is the hot path. Kept private to
+/// this module so it doesn't leak into the rest of the C ABI.
+fn walk_files_simple(root: &std::path::Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let walker = ignore::WalkBuilder::new(root)
+        .standard_filters(true)
+        .follow_links(false)
+        .threads(1)
+        .build();
+    for entry in walker.flatten() {
+        if entry.file_type().is_some_and(|t| t.is_file()) {
+            out.push(entry.into_path());
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Phase C — @-mention JSON surface tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod mention_abi_tests {
+    use super::*;
+    use std::ffi::CString;
+    use std::path::Path;
+
+    /// Build a tempdir with three files, then create an FfsInstance rooted
+    /// at it. Returns the `*mut c_void` handle (must be freed with
+    /// `ffs_destroy`).
+    unsafe fn fresh_instance(root: &Path) -> *mut c_void {
+        // Use empty paths for the optional DBs to keep the test hermetic.
+        let base = CString::new(root.to_str().unwrap()).unwrap();
+        let null = CString::new("").unwrap();
+        let res = unsafe {
+            ffs_create_instance2(
+                base.as_ptr(),
+                null.as_ptr(), // frecency
+                null.as_ptr(), // history
+                false,
+                false, // no mmap warmup
+                false, // no content indexing
+                false, // no watcher
+                true,  // ai_mode
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                0,
+                0,
+            )
+        };
+        assert!(!res.is_null(), "ffs_create_instance2 returned null");
+        let result = unsafe { &*res };
+        assert!(
+            result.success,
+            "ffs_create_instance2 failed: error={:?}",
+            result.error
+        );
+        let handle = result.handle;
+        // The FfsResult envelope is heap-allocated; free it via
+        // `ffs_free_result` so the error string is dropped exactly once.
+        unsafe { ffs_free_result(res) };
+        handle
+    }
+
+    /// Free the JSON string produced by `ffs_mention_search_json`.
+    unsafe fn free_handle(result: *mut FfsResult) {
+        unsafe {
+            if result.is_null() {
+                return;
+            }
+            let r = &*result;
+            if !r.error.is_null() {
+                drop(CString::from_raw(r.error));
+            }
+            if !r.handle.is_null() {
+                drop(CString::from_raw(r.handle as *mut c_char));
+            }
+            drop(Box::from_raw(result));
+        }
+    }
+
+    fn write_files(dir: &Path) {
+        std::fs::write(dir.join("alpha.rs"), b"fn alpha() {}\n").unwrap();
+        std::fs::write(dir.join("beta.rs"), b"fn beta() {}\n").unwrap();
+        std::fs::create_dir_all(dir.join("nested")).unwrap();
+        std::fs::write(dir.join("nested/gamma.rs"), b"fn gamma() {}\n").unwrap();
+    }
+
+    #[test]
+    fn mention_search_json_returns_valid_json_array() {
+        let td = tempfile::tempdir().unwrap();
+        write_files(td.path());
+        let handle = unsafe { fresh_instance(td.path()) };
+
+        let input = CString::new("alpha beta").unwrap();
+        let opts = CString::new("{\"max_tokens\": 1000}").unwrap();
+        let res = unsafe {
+            ffs_mention_search_json(handle, input.as_ptr(), 0, opts.as_ptr())
+        };
+        let r = unsafe { &*res };
+        assert!(r.success, "expected success, got error: {:?}", r.error);
+        assert!(!r.handle.is_null(), "expected non-null JSON handle");
+        let json_ptr = r.handle as *const c_char;
+        let json = unsafe { CStr::from_ptr(json_ptr) }.to_str().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(json)
+            .expect("ffs_mention_search_json should produce valid JSON");
+        let arr = parsed.as_array().expect("expected JSON array");
+        assert_eq!(arr.len(), 2, "expected 2 ResolvedMention entries: {json}");
+        for m in arr {
+            assert!(m["path"].is_string());
+            assert!(m["kind"].is_string());
+            assert!(m["content"].is_string() || m["content"].is_null());
+        }
+        unsafe { free_handle(res) };
+        unsafe { ffs_destroy(handle) };
+    }
+
+    #[test]
+    fn mention_search_json_empty_input_returns_empty_array() {
+        let td = tempfile::tempdir().unwrap();
+        write_files(td.path());
+        let handle = unsafe { fresh_instance(td.path()) };
+
+        let input = CString::new("   \t  ").unwrap();
+        let res =
+            unsafe { ffs_mention_search_json(handle, input.as_ptr(), 0, std::ptr::null()) };
+        let r = unsafe { &*res };
+        assert!(r.success, "expected success on empty input");
+        let json = unsafe { CStr::from_ptr(r.handle as *const c_char) }
+            .to_str()
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(json).unwrap();
+        assert!(parsed.as_array().unwrap().is_empty());
+        unsafe { free_handle(res) };
+        unsafe { ffs_destroy(handle) };
+    }
+
+    #[test]
+    fn mention_search_json_null_handle_returns_error() {
+        let input = CString::new("alpha").unwrap();
+        let res = unsafe {
+            ffs_mention_search_json(std::ptr::null_mut(), input.as_ptr(), 0, std::ptr::null())
+        };
+        let r = unsafe { &*res };
+        assert!(!r.success, "null handle must produce error result");
+        assert!(!r.error.is_null());
+        unsafe { free_handle(res) };
+    }
+
+    #[test]
+    fn mention_search_json_options_parse_error() {
+        let td = tempfile::tempdir().unwrap();
+        write_files(td.path());
+        let handle = unsafe { fresh_instance(td.path()) };
+
+        let input = CString::new("alpha").unwrap();
+        let opts = CString::new("not-json").unwrap();
+        let res = unsafe {
+            ffs_mention_search_json(handle, input.as_ptr(), 0, opts.as_ptr())
+        };
+        let r = unsafe { &*res };
+        assert!(!r.success, "malformed options_json must produce error");
+        unsafe { free_handle(res) };
+        unsafe { ffs_destroy(handle) };
+    }
 }

--- a/crates/ffs-cli/src/cli.rs
+++ b/crates/ffs-cli/src/cli.rs
@@ -94,6 +94,11 @@ pub enum Command {
     /// Run as MCP server over stdio (replaces agent built-ins Grep/Glob/Read).
     Mcp(commands::mcp::Args),
 
+    /// Resolve a @-mention payload (Phase C surface — wraps the Phase B
+    /// `resolve_mentions` engine API; tokens in the input become substring
+    /// candidate queries against the repo).
+    Mention(commands::mention::Args),
+
     /// Print the embedded agent guide.
     Guide(commands::guide::Args),
 }
@@ -144,6 +149,7 @@ impl Cli {
             Command::Map(a) => commands::map::run(a, &root, self.format),
             Command::Overview(a) => commands::overview::run(a, &root, self.format),
             Command::Mcp(a) => commands::mcp::run(a, &root),
+            Command::Mention(a) => commands::mention::run(a, &root, self.format),
             Command::Guide(a) => commands::guide::run(a, &root, self.format),
         }
     }

--- a/crates/ffs-cli/src/commands/mention.rs
+++ b/crates/ffs-cli/src/commands/mention.rs
@@ -1,0 +1,254 @@
+//! `ffs mention-search <input>` — Phase C surface for the @-mention system.
+//!
+//! Phase B (`ffs_engine::mention::resolve_mentions`) resolves filesystem
+//! resources into `ResolvedMention` payloads. Phase C wires three host
+//! surfaces onto that resolver:
+//!
+//!   1. The `ffs mention-search` subcommand (this file).
+//!   2. The `ffs_mention_search_json` C ABI (in `crates/ffs-c`).
+//!   3. The `ffs_mention_search` MCP tool (in `crates/ffs-mcp`).
+//!
+//! This subcommand takes a single input string, splits it into tokens, runs
+//! a tiny substring-based candidate search against the repo (no FilePicker
+//! — that would couple us to the indexed path DB, which is overkill for a
+//! mention surface), and then calls `resolve_mentions` for each candidate.
+//!
+//! The candidate selection is intentionally simple: each non-empty whitespace
+//! token becomes a substring query, all hits are unioned, deduped, and
+//! passed to the resolver. Phase A (lives on main, not in this worktree)
+//! will replace the substring pass with a proper candidate pipeline; the
+//! surface stays the same.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use clap::Parser;
+use serde::Serialize;
+
+use ffs_budget::FilterLevel;
+use ffs_engine::mention::{resolve_mentions, ResolveOptions, ResolvedMention};
+
+use crate::cli::OutputFormat;
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// Input string. Tokens are split on whitespace; each token becomes a
+    /// substring candidate query that is resolved by Phase B.
+    pub input: String,
+
+    /// Cursor into the input (1-based, informational only — surfaces
+    /// alignment with the MCP `cursor` parameter for future Phase D work).
+    #[arg(long)]
+    pub cursor: Option<usize>,
+
+    /// Output format. Defaults to JSON for stability across hosts.
+    #[arg(long, default_value = "json")]
+    pub format: String,
+
+    /// Maximum tokens of body allowed per resolved mention. Default 50_000
+    /// (mirrors `ResolveOptions::default`).
+    #[arg(long, default_value_t = 50000)]
+    pub max_tokens: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct MentionSearchOutput {
+    input: String,
+    cursor: Option<usize>,
+    candidates: Vec<String>,
+    total_candidates: usize,
+    mentions: Vec<ResolvedMention>,
+    schema: &'static str,
+}
+
+/// Run the mention-search subcommand. Walks `root`, finds files whose path
+/// contains any of the input's whitespace-separated tokens (case-sensitive
+/// substring), then hands the candidate paths to the Phase B resolver.
+///
+/// `format` is supplied as a string (per the spec's `format` arg). Anything
+/// other than `"text"` is treated as JSON for forward compatibility with new
+/// formats (yaml, toon, …).
+pub fn run(args: Args, root: &Path, default_format: OutputFormat) -> Result<()> {
+    let format = match args.format.to_ascii_lowercase().as_str() {
+        "text" => OutputFormat::Text,
+        _ => OutputFormat::Json,
+    };
+    // `default_format` is the global `--format` flag from the CLI; the
+    // subcommand's own `--format` flag wins when present (and it always is,
+    // since we set a default). Kept in the signature for symmetry with
+    // other commands and to make it easy to flip the precedence later.
+    let _ = default_format;
+
+    let candidates = collect_candidates(root, &args.input);
+    let paths: Vec<PathBuf> = candidates.iter().map(PathBuf::from).collect();
+
+    let opts = ResolveOptions {
+        max_tokens: args.max_tokens,
+        filter_level: FilterLevel::Minimal,
+        line_range: None,
+    };
+    let mentions = resolve_mentions(&paths, &opts);
+
+    let payload = MentionSearchOutput {
+        input: args.input,
+        cursor: args.cursor,
+        total_candidates: candidates.len(),
+        candidates,
+        mentions,
+        schema: "v1",
+    };
+
+    super::emit(format, &payload, |p| render_text(p))
+}
+
+fn render_text(p: &MentionSearchOutput) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# ffs mention-search ({} candidates, schema {})\n",
+        p.total_candidates, p.schema
+    ));
+    for (i, _c) in p.candidates.iter().enumerate() {
+        let m = &p.mentions[i];
+        let body = m.content.as_deref().unwrap_or("<none>");
+        out.push_str(&format!(
+            "\n--- {} [{}] ({} tokens) ---\n{}\n",
+            m.path.display(),
+            match m.kind {
+                ffs_engine::mention::MentionKind::File => "file",
+                ffs_engine::mention::MentionKind::Directory => "directory",
+                ffs_engine::mention::MentionKind::Image => "image",
+            },
+            m.token_cost,
+            body
+        ));
+        if let Some(err) = &m.audit.error {
+            out.push_str(&format!("! error: {err}\n"));
+        }
+    }
+    out
+}
+
+/// Walk `root` and return every absolute path whose stringified form
+/// contains any of the whitespace-separated tokens in `input` (case-sensitive
+/// substring). Order is arrival order from the parallel walker; we sort +
+/// dedup so JSON output is deterministic.
+fn collect_candidates(root: &Path, input: &str) -> Vec<String> {
+    use std::collections::HashSet;
+
+    let tokens: Vec<&str> = input
+        .split_whitespace()
+        .filter(|t| !t.is_empty())
+        .collect();
+    if tokens.is_empty() {
+        return Vec::new();
+    }
+
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<String> = Vec::new();
+    for path in super::walk_files(root) {
+        let Some(s) = path.to_str() else { continue };
+        if tokens.iter().any(|t| s.contains(t)) && seen.insert(s.to_string()) {
+            out.push(s.to_string());
+        }
+    }
+    out.sort();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_files(dir: &Path) {
+        std::fs::write(dir.join("alpha.rs"), "fn alpha() {}\n").unwrap();
+        std::fs::write(dir.join("beta.rs"), "fn beta() {}\n").unwrap();
+        std::fs::create_dir_all(dir.join("nested")).unwrap();
+        std::fs::write(dir.join("nested/gamma.rs"), "fn gamma() {}\n").unwrap();
+    }
+
+    #[test]
+    fn collect_candidates_substring_match() {
+        let td = tempfile::tempdir().unwrap();
+        make_files(td.path());
+        let hits = collect_candidates(td.path(), "alpha");
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].ends_with("alpha.rs"));
+    }
+
+    #[test]
+    fn collect_candidates_multiple_tokens_unioned() {
+        let td = tempfile::tempdir().unwrap();
+        make_files(td.path());
+        let hits = collect_candidates(td.path(), "alpha beta");
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn collect_candidates_empty_input_returns_empty() {
+        let td = tempfile::tempdir().unwrap();
+        make_files(td.path());
+        let hits = collect_candidates(td.path(), "   \t  ");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn collect_candidates_dedups_when_same_token_repeated() {
+        let td = tempfile::tempdir().unwrap();
+        make_files(td.path());
+        let hits = collect_candidates(td.path(), "alpha alpha");
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn run_produces_resolved_mention_for_matched_file() {
+        let td = tempfile::tempdir().unwrap();
+        make_files(td.path());
+        let args = Args {
+            input: "alpha".into(),
+            cursor: None,
+            format: "json".into(),
+            max_tokens: 1000,
+        };
+        run(args, td.path(), OutputFormat::Json).unwrap();
+    }
+
+    #[test]
+    fn run_handles_text_format() {
+        let td = tempfile::tempdir().unwrap();
+        make_files(td.path());
+        let args = Args {
+            input: "alpha".into(),
+            cursor: Some(0),
+            format: "text".into(),
+            max_tokens: 1000,
+        };
+        run(args, td.path(), OutputFormat::Text).unwrap();
+    }
+
+    #[test]
+    fn run_handles_unknown_format_as_json() {
+        let td = tempfile::tempdir().unwrap();
+        make_files(td.path());
+        let args = Args {
+            input: "alpha".into(),
+            cursor: None,
+            format: "yaml".into(),
+            max_tokens: 1000,
+        };
+        run(args, td.path(), OutputFormat::Json).unwrap();
+    }
+
+    #[test]
+    fn run_returns_no_mentions_for_no_match() {
+        let td = tempfile::tempdir().unwrap();
+        make_files(td.path());
+        let args = Args {
+            input: "this_file_does_not_exist_zzz".into(),
+            cursor: None,
+            format: "json".into(),
+            max_tokens: 1000,
+        };
+        // No candidates => empty Vec<ResolvedMention>. No error.
+        run(args, td.path(), OutputFormat::Json).unwrap();
+    }
+}

--- a/crates/ffs-cli/src/commands/mod.rs
+++ b/crates/ffs-cli/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub mod impact;
 pub mod index;
 pub mod map;
 pub mod mcp;
+pub mod mention;
 pub mod outline;
 pub(crate) mod outline_format;
 pub mod overview;

--- a/crates/ffs-core/src/mention/mod.rs
+++ b/crates/ffs-core/src/mention/mod.rs
@@ -61,5 +61,12 @@
 mod resolver;
 mod trigger;
 
+/// Phase D: extensible @-mention provider protocol. See module docs.
+pub mod provider;
+
+pub use provider::{
+    ExternalMentionCandidate, ExternalResolveResult, MentionProvider, ProviderError,
+    ProviderRegistry,
+};
 pub use resolver::{MentionCandidate, MentionKind, MentionOptions, MentionResolver, MentionResult};
 pub use trigger::{MentionTrigger, detect_trigger};

--- a/crates/ffs-core/src/mention/provider.rs
+++ b/crates/ffs-core/src/mention/provider.rs
@@ -1,0 +1,458 @@
+//! Provider trait and registry implementation.
+//!
+//! See module-level docs in [`super`](crate::mention) for the Phase D
+//! design rationale and the FFI/thread-safety contract.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// A host-implemented provider of custom @-mention kinds.
+///
+/// Examples: `agent`, `tool`, `skill`, `image`, `mcp_resource`.
+///
+/// Implementors must be **cheap to clone behind an `Arc`** — the registry
+/// hands out `Arc<dyn MentionProvider>` clones on every `get`. Methods
+/// are synchronous and `&self`; for I/O, spawn a worker and return
+/// results. The trait has no generic parameters, so `Arc<dyn MentionProvider>`
+/// is FFI-safe (no monomorphization, no `Self: Sized`).
+pub trait MentionProvider: Send + Sync {
+    /// The @-kind this provider serves, e.g. `"agent"`, `"tool"`, `"skill"`,
+    /// `"image"`, `"mcp_resource"`. Must be unique within a registry.
+    /// Returned as `&'static str` because the kind is part of the type's
+    /// identity — it cannot change at runtime.
+    fn kind(&self) -> &'static str;
+
+    /// Best-effort completion suggestions for a partial key. The provider
+    /// decides how to score and rank — the host just displays the top
+    /// `limit` results. Returning an empty `Vec` means "no suggestions",
+    /// which is distinct from an error.
+    fn suggest(&self, query: &str, limit: usize) -> Vec<ExternalMentionCandidate>;
+
+    /// Resolve a fully-typed key into a concrete payload. Returning
+    /// `Err(ProviderError::NotFound(_))` tells the host the key is not
+    /// recognized by this provider.
+    fn resolve(&self, key: &str) -> Result<ExternalResolveResult, ProviderError>;
+
+    /// Whether this provider performs only local computation. Override
+    /// to return `false` for providers that fetch over the network
+    /// (the *oh-my-pi* invariant: a single `resolve` may not perform
+    /// network I/O without explicit user consent).
+    fn is_local(&self) -> bool {
+        true
+    }
+}
+
+/// A single completion suggestion returned from [`MentionProvider::suggest`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalMentionCandidate {
+    /// The unique key the host should pass back to
+    /// [`MentionProvider::resolve`] when this candidate is selected.
+    pub key: String,
+    /// Human-readable display name shown in the completion popup.
+    pub display: String,
+    /// Optional one-line description / subtitle.
+    pub description: Option<String>,
+}
+
+/// The concrete payload returned from [`MentionProvider::resolve`].
+///
+/// Each variant carries the data needed by the host to *act on* the
+/// mention (e.g. spawn an agent, call a tool, embed an image).
+/// `Other(String)` is an escape hatch for host-defined kinds that don't
+/// fit the built-in variants; hosts may serialize it as opaque JSON.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExternalResolveResult {
+    /// Spawn hint for an agent. The host decides how to interpret it
+    /// (subprocess, RPC, in-process task, etc.).
+    Agent { spawn_hint: String },
+    /// A callable tool / function signature (typically a JSON Schema or
+    /// language-specific signature string).
+    Tool { signature: String },
+    /// A skill body (markdown / natural-language instructions) and the
+    /// on-disk location the body was loaded from.
+    Skill { body: String, location: PathBuf },
+    /// An image, inlined as base64 with its MIME type.
+    Image { base64: String, mime: String },
+    /// A resource exposed by an MCP server.
+    McpResource { uri: String, content: String },
+    /// Opaque fallback for kinds that don't fit the variants above.
+    /// Hosts should preserve the string verbatim and surface it to the
+    /// model as raw text.
+    Other(String),
+}
+
+/// Errors a provider can return from [`MentionProvider::resolve`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderError {
+    /// The key is not recognized by this provider. The host may try a
+    /// different provider, fall back to a file lookup, or surface a
+    /// "not found" error to the user.
+    NotFound(String),
+    /// A local I/O error (file read failed, permission denied, etc.).
+    /// The wrapped `String` is a human-readable diagnostic.
+    IoError(String),
+    /// A network error. Providers that ever return this should override
+    /// [`MentionProvider::is_local`] to return `false`.
+    NetworkError(String),
+}
+
+impl fmt::Display for ProviderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProviderError::NotFound(k) => write!(f, "not found: {k}"),
+            ProviderError::IoError(m) => write!(f, "io error: {m}"),
+            ProviderError::NetworkError(m) => write!(f, "network error: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for ProviderError {}
+
+/// A registry of `MentionProvider`s keyed by [`MentionProvider::kind`].
+///
+/// The registry is `!Sync`-in-itself but the trait object inside is
+/// `Send + Sync`, so `Arc<ProviderRegistry>` is safe to share across
+/// threads. Lookups are O(1) average (hash map).
+pub struct ProviderRegistry {
+    providers: HashMap<&'static str, Arc<dyn MentionProvider>>,
+}
+
+impl ProviderRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            providers: HashMap::new(),
+        }
+    }
+
+    /// Register a provider. The provider's `kind()` becomes the lookup
+    /// key. Re-registering the same kind replaces the previous entry —
+    /// useful for hot-reload scenarios in long-lived host processes.
+    pub fn register(&mut self, provider: Arc<dyn MentionProvider>) {
+        self.providers.insert(provider.kind(), provider);
+    }
+
+    /// Look up a provider by kind. Returns `None` if no provider is
+    /// registered for `kind`.
+    pub fn get(&self, kind: &str) -> Option<Arc<dyn MentionProvider>> {
+        self.providers.get(kind).cloned()
+    }
+
+    /// All registered kinds, in arbitrary order. The returned slice
+    /// borrows from the registry, so it lives at most as long as `self`.
+    pub fn list_kinds(&self) -> Vec<&'static str> {
+        self.providers.keys().copied().collect()
+    }
+}
+
+impl Default for ProviderRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// A minimal provider used by most tests. Always local by default;
+    /// `network()` flips `is_local` to `false` for the oh-my-pi guard.
+    struct StubProvider {
+        kind: &'static str,
+        candidates: Vec<ExternalMentionCandidate>,
+        local: bool,
+        resolve: Box<dyn Fn(&str) -> Result<ExternalResolveResult, ProviderError> + Send + Sync>,
+    }
+
+    impl StubProvider {
+        fn new(kind: &'static str, candidates: Vec<ExternalMentionCandidate>) -> Self {
+            Self {
+                kind,
+                candidates,
+                local: true,
+                resolve: Box::new(|key| Err(ProviderError::NotFound(key.to_string()))),
+            }
+        }
+
+        fn with_resolver(
+            mut self,
+            f: impl Fn(&str) -> Result<ExternalResolveResult, ProviderError> + Send + Sync + 'static,
+        ) -> Self {
+            self.resolve = Box::new(f);
+            self
+        }
+
+        fn network(mut self) -> Self {
+            self.local = false;
+            self
+        }
+    }
+
+    impl MentionProvider for StubProvider {
+        fn kind(&self) -> &'static str {
+            self.kind
+        }
+
+        fn suggest(&self, query: &str, limit: usize) -> Vec<ExternalMentionCandidate> {
+            self.candidates
+                .iter()
+                .filter(|c| query.is_empty() || c.key.contains(query) || c.display.contains(query))
+                .take(limit)
+                .cloned()
+                .collect()
+        }
+
+        fn resolve(&self, key: &str) -> Result<ExternalResolveResult, ProviderError> {
+            (self.resolve)(key)
+        }
+
+        fn is_local(&self) -> bool {
+            self.local
+        }
+    }
+
+    // ----- tests -----
+
+    #[test]
+    fn empty_registry_has_no_kinds() {
+        let r = ProviderRegistry::new();
+        assert!(r.list_kinds().is_empty());
+        assert!(r.get("anything").is_none());
+    }
+
+    #[test]
+    fn default_registry_matches_new() {
+        let r = ProviderRegistry::default();
+        assert!(r.list_kinds().is_empty());
+    }
+
+    #[test]
+    fn register_and_lookup_by_kind() {
+        let mut r = ProviderRegistry::new();
+        let p = Arc::new(StubProvider::new("agent", vec![]));
+        r.register(p);
+        let got = r.get("agent").expect("agent should be registered");
+        assert_eq!(got.kind(), "agent");
+    }
+
+    #[test]
+    fn list_kinds_returns_all_registered() {
+        let mut r = ProviderRegistry::new();
+        r.register(Arc::new(StubProvider::new("agent", vec![])));
+        r.register(Arc::new(StubProvider::new("tool", vec![])));
+        r.register(Arc::new(StubProvider::new("skill", vec![])));
+        let mut kinds = r.list_kinds();
+        kinds.sort_unstable();
+        assert_eq!(kinds, vec!["agent", "skill", "tool"]);
+    }
+
+    #[test]
+    fn multiple_providers_of_different_kinds_coexist() {
+        let mut r = ProviderRegistry::new();
+        r.register(Arc::new(StubProvider::new("agent", vec![])));
+        r.register(Arc::new(StubProvider::new("tool", vec![])));
+        assert_eq!(r.get("agent").unwrap().kind(), "agent");
+        assert_eq!(r.get("tool").unwrap().kind(), "tool");
+        assert!(r.get("skill").is_none());
+    }
+
+    #[test]
+    fn reregister_replaces_existing_provider() {
+        let mut r = ProviderRegistry::new();
+        r.register(Arc::new(StubProvider::new("agent", vec![])));
+        r.register(Arc::new(StubProvider::new(
+            "agent",
+            vec![ExternalMentionCandidate {
+                key: "v2".into(),
+                display: "v2".into(),
+                description: None,
+            }],
+        )));
+        // Re-registering the same kind replaces, not duplicates.
+        assert_eq!(r.list_kinds().len(), 1);
+        let p = r.get("agent").unwrap();
+        let cands = p.suggest("", 10);
+        assert_eq!(cands.len(), 1);
+        assert_eq!(cands[0].key, "v2");
+    }
+
+    #[test]
+    fn suggest_returns_candidates_matching_query() {
+        let cands = vec![
+            ExternalMentionCandidate {
+                key: "reviewer".into(),
+                display: "Reviewer".into(),
+                description: Some("Reviews code".into()),
+            },
+            ExternalMentionCandidate {
+                key: "writer".into(),
+                display: "Writer".into(),
+                description: Some("Writes docs".into()),
+            },
+        ];
+        let p = StubProvider::new("agent", cands);
+        // Query "rev" should match only the reviewer.
+        let got = p.suggest("rev", 10);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].key, "reviewer");
+    }
+
+    #[test]
+    fn suggest_respects_limit() {
+        let cands: Vec<ExternalMentionCandidate> = (0..5)
+            .map(|i| ExternalMentionCandidate {
+                key: format!("k{i}"),
+                display: format!("d{i}"),
+                description: None,
+            })
+            .collect();
+        let p = StubProvider::new("tool", cands);
+        let got = p.suggest("", 2);
+        assert_eq!(got.len(), 2);
+    }
+
+    #[test]
+    fn suggest_empty_query_returns_all_capped_by_limit() {
+        let cands: Vec<ExternalMentionCandidate> = (0..3)
+            .map(|i| ExternalMentionCandidate {
+                key: format!("k{i}"),
+                display: format!("d{i}"),
+                description: None,
+            })
+            .collect();
+        let p = StubProvider::new("tool", cands);
+        let got = p.suggest("", 100);
+        assert_eq!(got.len(), 3);
+    }
+
+    #[test]
+    fn resolve_returns_ok_for_known_key() {
+        let p = StubProvider::new("agent", vec![]).with_resolver(|key| {
+            Ok(ExternalResolveResult::Agent {
+                spawn_hint: format!("spawn {key}"),
+            })
+        });
+        let got = p.resolve("reviewer").expect("resolve should succeed");
+        match got {
+            ExternalResolveResult::Agent { spawn_hint } => {
+                assert_eq!(spawn_hint, "spawn reviewer");
+            }
+            _ => panic!("expected Agent variant"),
+        }
+    }
+
+    #[test]
+    fn resolve_returns_not_found_for_unknown_key() {
+        let p = StubProvider::new("tool", vec![]);
+        let err = p.resolve("nope").unwrap_err();
+        assert_eq!(err, ProviderError::NotFound("nope".into()));
+    }
+
+    #[test]
+    fn is_local_defaults_to_true() {
+        let p = StubProvider::new("agent", vec![]);
+        assert!(p.is_local());
+    }
+
+    #[test]
+    fn is_local_can_be_overridden_to_false() {
+        let p = StubProvider::new("skill", vec![]).network();
+        assert!(!p.is_local());
+    }
+
+    #[test]
+    fn registry_get_returns_arc_clones() {
+        let mut r = ProviderRegistry::new();
+        let p: Arc<dyn MentionProvider> = Arc::new(StubProvider::new("agent", vec![]));
+        r.register(Arc::clone(&p));
+        let a = r.get("agent").unwrap();
+        let b = r.get("agent").unwrap();
+        // Arc::ptr_eq compares the underlying pointer.
+        assert!(Arc::ptr_eq(&a, &b));
+        assert!(Arc::ptr_eq(&a, &p));
+    }
+
+    #[test]
+    fn trait_object_is_send_and_sync() {
+        // This is a *compile-time* check: the function will not type-check
+        // if `dyn MentionProvider` is not `Send + Sync`.
+        fn assert_send_sync<T: Send + Sync + ?Sized>() {}
+        assert_send_sync::<dyn MentionProvider>();
+    }
+
+    #[test]
+    fn arc_dyn_provider_is_send_and_sync() {
+        // Belt-and-braces: the *Arc* wrapping the trait object must also
+        // be `Send + Sync` for the registry to be shareable across threads.
+        fn assert_send_sync<T: Send + Sync + ?Sized>() {}
+        assert_send_sync::<Arc<dyn MentionProvider>>();
+    }
+
+    #[test]
+    fn provider_with_shared_state_is_send_sync() {
+        // A provider that owns a Mutex is still `Send + Sync` because the
+        // Mutex itself is. This guards against accidental `Rc` / `*mut`
+        // usage slipping into providers.
+        struct CountingProvider {
+            count: Mutex<u32>,
+        }
+        impl MentionProvider for CountingProvider {
+            fn kind(&self) -> &'static str {
+                "counter"
+            }
+            fn suggest(&self, _query: &str, _limit: usize) -> Vec<ExternalMentionCandidate> {
+                *self.count.lock().unwrap() += 1;
+                vec![]
+            }
+            fn resolve(&self, _key: &str) -> Result<ExternalResolveResult, ProviderError> {
+                Err(ProviderError::NotFound("n/a".into()))
+            }
+        }
+        let p: Arc<dyn MentionProvider> = Arc::new(CountingProvider {
+            count: Mutex::new(0),
+        });
+        // Use it from the type system to confirm it satisfies the bounds.
+        let mut r = ProviderRegistry::new();
+        r.register(p);
+        assert_eq!(r.get("counter").unwrap().kind(), "counter");
+    }
+
+    #[test]
+    fn provider_error_display_is_readable() {
+        let e = ProviderError::NotFound("k".into());
+        assert_eq!(e.to_string(), "not found: k");
+        let e = ProviderError::IoError("read failed".into());
+        assert_eq!(e.to_string(), "io error: read failed");
+        let e = ProviderError::NetworkError("dns".into());
+        assert_eq!(e.to_string(), "network error: dns");
+    }
+
+    #[test]
+    fn external_resolve_result_variants_are_constructable() {
+        // Smoke-test every variant to make sure the public surface
+        // stays usable. Phase C serializes these through the C ABI JSON
+        // bridge, so any future change here is a breaking change.
+        let _ = ExternalResolveResult::Agent {
+            spawn_hint: "x".into(),
+        };
+        let _ = ExternalResolveResult::Tool {
+            signature: "fn()".into(),
+        };
+        let _ = ExternalResolveResult::Skill {
+            body: "body".into(),
+            location: PathBuf::from("/tmp/skill.md"),
+        };
+        let _ = ExternalResolveResult::Image {
+            base64: "AAA=".into(),
+            mime: "image/png".into(),
+        };
+        let _ = ExternalResolveResult::McpResource {
+            uri: "fs://x".into(),
+            content: "{}".into(),
+        };
+        let _ = ExternalResolveResult::Other("opaque".into());
+    }
+}

--- a/crates/ffs-engine/src/lib.rs
+++ b/crates/ffs-engine/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod classify;
 pub mod dispatch;
 pub mod memory;
+pub mod mention;
 pub mod prefilter;
 pub mod ranking;
 pub mod scanner;
@@ -11,6 +12,10 @@ pub mod scanner;
 pub use classify::{classify_query, ClassifiedQuery};
 pub use dispatch::{Engine, EngineConfig, EngineHandles};
 pub use memory::{MemoryGuard, RepoSize};
+pub use mention::{
+    MentionAudit, MentionKind, MentionResolverCache, ResolveOptions, ResolvedMention,
+    resolve_mentions,
+};
 pub use prefilter::{PreFilterStack, PreFilteredCandidate};
 pub use ranking::{rank_matches, RankInputs};
 pub use scanner::{IndexedFile, ScanProgress, ScanReport, UnifiedScanner};

--- a/crates/ffs-engine/src/lib.rs
+++ b/crates/ffs-engine/src/lib.rs
@@ -13,8 +13,8 @@ pub use classify::{classify_query, ClassifiedQuery};
 pub use dispatch::{Engine, EngineConfig, EngineHandles};
 pub use memory::{MemoryGuard, RepoSize};
 pub use mention::{
-    MentionAudit, MentionKind, MentionResolverCache, ResolveOptions, ResolvedMention,
-    resolve_mentions,
+    resolve_mentions, MentionAudit, MentionKind, MentionResolverCache, ResolveOptions,
+    ResolvedMention,
 };
 pub use prefilter::{PreFilterStack, PreFilteredCandidate};
 pub use ranking::{rank_matches, RankInputs};

--- a/crates/ffs-engine/src/mention.rs
+++ b/crates/ffs-engine/src/mention.rs
@@ -1,0 +1,818 @@
+//! Phase B of the @-mention system: payload resolution.
+//!
+//! Given a list of paths selected by the host (CLI / MCP / C ABI / D provider),
+//! `resolve_mentions` reads each one, classifies it (text / binary / image /
+//! directory), applies a `FilterLevel`, applies a `line_range` slice, then
+//! `smart_truncate`s to fit the caller's token budget. Results include an
+//! `audit` field for debugging expensive resolutions.
+//!
+//! `MentionResolverCache` is a tiny dedup-by-turn cache so the same path
+//! resolved twice in a single host turn returns the cached `ResolvedMention`
+//! without re-reading the file or re-applying the filter pipeline.
+//!
+//! This module is intentionally self-contained: it does not depend on the
+//! Phase A `MentionCandidate` type (which lives in `ffs-core::mention`),
+//! because Phase A is not part of this worktree base. Hosts pass in a slice
+//! of `PathBuf` and get back a `Vec<ResolvedMention>` of the same length.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use ffs_budget::{
+    estimate_tokens, smart_truncate, tokens_to_bytes, AggressiveFilter, FilterLevel,
+    FilterStrategy, MinimalFilter, NoFilter, TruncationOutcome,
+};
+use serde::{Deserialize, Serialize};
+
+/// Maximum bytes read for binary detection. The probe never reads more than
+/// this so a 10GB file does not block the resolver.
+const BINARY_PROBE_BYTES: usize = 8 * 1024;
+
+/// Maximum entries in a directory listing. Keeps the resolved payload bounded.
+const DIRECTORY_LISTING_CAP: usize = 100;
+
+/// Image extensions recognized by the resolver. Anything matching is marked
+/// `MentionKind::Image` and never opened as text.
+const IMAGE_EXTS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp"];
+
+/// MIME type for each recognized image extension.
+fn image_mime_for(ext: &str) -> Option<&'static str> {
+    match ext.to_ascii_lowercase().as_str() {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        _ => None,
+    }
+}
+
+/// The kind of resource a @-mention resolves to in Phase B.
+///
+/// `External(&'static str)` from Phase A is intentionally absent: Phase B
+/// only resolves filesystem resources. Phase D will reintroduce the
+/// provider trait; for now anything not in {File, Directory, Image} falls
+/// through to a plain `File` with `content = None`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MentionKind {
+    File,
+    Directory,
+    Image,
+}
+
+/// Audit information attached to every `ResolvedMention`. Used by the host
+/// to surface "why did this read cost so much" without re-walking the
+/// resolver pipeline.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MentionAudit {
+    /// Pipeline phase that produced this audit (always "B" for now;
+    /// Phase D will tag external provider passes differently).
+    pub phase: String,
+    /// Token cost of the content *before* truncation. Lets the caller
+    /// see how much `smart_truncate` actually saved.
+    pub tokens_before_truncate: u32,
+    /// Set when the resolver hit an I/O or classification error.
+    /// `content` will be `None` and `kind` will reflect what the resolver
+    /// was *able* to determine (often `File` with no body).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Caller-tunable knobs for a single resolve pass.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolveOptions {
+    /// Maximum tokens of *body* allowed for each resolved mention. The
+    /// resolver converts to a byte budget internally. Default 50_000.
+    pub max_tokens: u32,
+    /// Comment / whitespace stripping intensity. Default `Minimal`.
+    pub filter_level: FilterLevel,
+    /// Optional `(start_line, end_line)` 1-based inclusive slice. Applied
+    /// *before* `smart_truncate` so the line range is honored even when
+    /// the underlying file is large.
+    pub line_range: Option<(u32, u32)>,
+}
+
+impl Default for ResolveOptions {
+    fn default() -> Self {
+        Self {
+            max_tokens: 50_000,
+            filter_level: FilterLevel::Minimal,
+            line_range: None,
+        }
+    }
+}
+
+/// The resolved payload for a single @-mention.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolvedMention {
+    /// Absolute path the resolver actually read. Always set; if the host
+    /// passed a relative path, it was canonicalized against the process
+    /// CWD before resolution.
+    pub path: PathBuf,
+    pub kind: MentionKind,
+    pub line_range: Option<(u32, u32)>,
+    pub size: u64,
+    pub is_binary: bool,
+    /// Text body. `None` for binary / image / directory, or for an
+    /// unreadable file (in which case `audit.error` is set).
+    pub content: Option<String>,
+    /// Base64-encoded image body. Always `None` in Phase B — the resolver
+    /// does not load image bytes; it only sets `image_mime` so the host
+    /// can decide whether to base64-encode later. The field exists so the
+    /// shape is stable for Phase C (MCP) and Phase D (external providers).
+    pub image_base64: Option<String>,
+    /// Image MIME for the recognized extension. `None` for non-images.
+    pub image_mime: Option<String>,
+    /// Set when `smart_truncate` actually dropped bytes. Lets the host
+    /// surface a "truncated, [N more lines]" hint to the user.
+    pub truncation: Option<TruncationOutcome>,
+    /// Token cost of the *final* (post-truncation, post-filter) content.
+    /// Zero when `content` is `None`.
+    pub token_cost: u32,
+    pub audit: MentionAudit,
+}
+
+/// Resolve a batch of paths in order. Returns one `ResolvedMention` per
+/// input path, in the same order. Never panics: every error becomes a
+/// `ResolvedMention { content: None, audit.error: Some(..) }`.
+pub fn resolve_mentions(paths: &[PathBuf], opts: &ResolveOptions) -> Vec<ResolvedMention> {
+    paths.iter().map(|p| resolve_one(p, opts)).collect()
+}
+
+fn resolve_one(path: &Path, opts: &ResolveOptions) -> ResolvedMention {
+    // Canonicalize so the caller always sees an absolute path. On error
+    // (path doesn't exist, permission denied) we still return a mention
+    // with kind=File and content=None + audit.error.
+    let abs = match fs::canonicalize(path) {
+        Ok(p) => p,
+        Err(e) => {
+            return ResolvedMention {
+                path: path.to_path_buf(),
+                kind: MentionKind::File,
+                line_range: opts.line_range,
+                size: 0,
+                is_binary: false,
+                content: None,
+                image_base64: None,
+                image_mime: None,
+                truncation: None,
+                token_cost: 0,
+                audit: MentionAudit {
+                    phase: "B".to_string(),
+                    tokens_before_truncate: 0,
+                    error: Some(e.to_string()),
+                },
+            };
+        }
+    };
+
+    let metadata = match fs::metadata(&abs) {
+        Ok(m) => m,
+        Err(e) => {
+            return ResolvedMention {
+                path: abs,
+                kind: MentionKind::File,
+                line_range: opts.line_range,
+                size: 0,
+                is_binary: false,
+                content: None,
+                image_base64: None,
+                image_mime: None,
+                truncation: None,
+                token_cost: 0,
+                audit: MentionAudit {
+                    phase: "B".to_string(),
+                    tokens_before_truncate: 0,
+                    error: Some(e.to_string()),
+                },
+            };
+        }
+    };
+
+    // Directory short-circuit: list immediate children, do not recurse.
+    if metadata.is_dir() {
+        return resolve_directory(&abs, &metadata);
+    }
+
+    let size = metadata.len();
+    let ext = abs
+        .extension()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+
+    // Image short-circuit: mark Image, do not open as text.
+    if IMAGE_EXTS.contains(&ext.as_str()) {
+        return ResolvedMention {
+            path: abs,
+            kind: MentionKind::Image,
+            line_range: opts.line_range,
+            size,
+            is_binary: true,
+            content: None,
+            image_base64: None,
+            image_mime: image_mime_for(&ext).map(|s| s.to_string()),
+            truncation: None,
+            token_cost: 0,
+            audit: MentionAudit {
+                phase: "B".to_string(),
+                tokens_before_truncate: 0,
+                error: None,
+            },
+        };
+    }
+
+    // Regular file. Binary-detection probe first, then text path.
+    match read_and_classify(&abs) {
+        ClassifiedFile::Text(content) => {
+            resolve_text(&abs, size, content, opts)
+        }
+        ClassifiedFile::Binary => ResolvedMention {
+            path: abs,
+            kind: MentionKind::File,
+            line_range: opts.line_range,
+            size,
+            is_binary: true,
+            content: None,
+            image_base64: None,
+            image_mime: None,
+            truncation: None,
+            token_cost: 0,
+            audit: MentionAudit {
+                phase: "B".to_string(),
+                tokens_before_truncate: 0,
+                error: None,
+            },
+        },
+        ClassifiedFile::IoError(e) => ResolvedMention {
+            path: abs,
+            kind: MentionKind::File,
+            line_range: opts.line_range,
+            size,
+            is_binary: false,
+            content: None,
+            image_base64: None,
+            image_mime: None,
+            truncation: None,
+            token_cost: 0,
+            audit: MentionAudit {
+                phase: "B".to_string(),
+                tokens_before_truncate: 0,
+                error: Some(e),
+            },
+        },
+    }
+}
+
+enum ClassifiedFile {
+    Text(String),
+    Binary,
+    IoError(String),
+}
+
+fn read_and_classify(path: &Path) -> ClassifiedFile {
+    let mut file = match fs::File::open(path) {
+        Ok(f) => f,
+        Err(e) => return ClassifiedFile::IoError(e.to_string()),
+    };
+    let mut probe = [0u8; BINARY_PROBE_BYTES];
+    let probe_len = match file.read(&mut probe) {
+        Ok(n) => n,
+        Err(e) => return ClassifiedFile::IoError(e.to_string()),
+    };
+    if probe[..probe_len].contains(&0u8) {
+        return ClassifiedFile::Binary;
+    }
+    // Re-open and read the whole file as text. We use lossy UTF-8 so
+    // a stray multi-byte sequence in an otherwise-text file still
+    // produces *some* string the host can show.
+    let full = match fs::read(path) {
+        Ok(b) => b,
+        Err(e) => return ClassifiedFile::IoError(e.to_string()),
+    };
+    ClassifiedFile::Text(String::from_utf8_lossy(&full).into_owned())
+}
+
+fn resolve_directory(path: &Path, metadata: &fs::Metadata) -> ResolvedMention {
+    let entries = match fs::read_dir(path) {
+        Ok(rd) => rd,
+        Err(e) => {
+            return ResolvedMention {
+                path: path.to_path_buf(),
+                kind: MentionKind::Directory,
+                line_range: None,
+                size: 0,
+                is_binary: false,
+                content: None,
+                image_base64: None,
+                image_mime: None,
+                truncation: None,
+                token_cost: 0,
+                audit: MentionAudit {
+                    phase: "B".to_string(),
+                    tokens_before_truncate: 0,
+                    error: Some(e.to_string()),
+                },
+            };
+        }
+    };
+
+    let mut names: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+
+    let truncated = names.len() > DIRECTORY_LISTING_CAP;
+    if truncated {
+        names.truncate(DIRECTORY_LISTING_CAP);
+    }
+    let body = names.join("\n");
+    let body_with_marker = if truncated {
+        format!(
+            "{}\n[{} more entries truncated]\n",
+            body,
+            DIRECTORY_LISTING_CAP // upper bound on hidden count
+        )
+    } else {
+        body
+    };
+    let final_len = body_with_marker.len();
+
+    let token_cost = estimate_tokens(final_len as u64) as u32;
+    ResolvedMention {
+        path: path.to_path_buf(),
+        kind: MentionKind::Directory,
+        line_range: None,
+        size: metadata.len(),
+        is_binary: false,
+        content: Some(body_with_marker),
+        image_base64: None,
+        image_mime: None,
+        truncation: if truncated {
+            Some(TruncationOutcome {
+                kept_lines: DIRECTORY_LISTING_CAP,
+                dropped_lines: 0, // unknown; cap was reached
+                kept_bytes: final_len,
+                footer_bytes: 0,
+            })
+        } else {
+            None
+        },
+        token_cost,
+        audit: MentionAudit {
+            phase: "B".to_string(),
+            tokens_before_truncate: token_cost,
+            error: None,
+        },
+    }
+}
+
+fn resolve_text(
+    path: &Path,
+    size: u64,
+    raw: String,
+    opts: &ResolveOptions,
+) -> ResolvedMention {
+    // 1. Apply line range slice (1-based, inclusive on both ends).
+    let sliced = match opts.line_range {
+        Some((start, end)) if start > 0 => slice_lines(&raw, start, end),
+        _ => raw.clone(),
+    };
+
+    // 2. Apply filter.
+    let filtered = apply_filter(&sliced, opts.filter_level);
+
+    // 3. Truncate to token budget. Convert tokens -> bytes using the
+    //    same 4-bytes-per-token estimate the budget module uses
+    //    everywhere else, so the resolver and `read` agree on what
+    //    "fits in 50k tokens" means.
+    let max_bytes = tokens_to_bytes(u64::from(opts.max_tokens)) as usize;
+    let (body, truncation) = smart_truncate(&filtered, max_bytes);
+
+    let tokens_before = estimate_tokens(filtered.len() as u64) as u32;
+    let token_cost = estimate_tokens(body.len() as u64) as u32;
+
+    ResolvedMention {
+        path: path.to_path_buf(),
+        kind: MentionKind::File,
+        line_range: opts.line_range,
+        size,
+        is_binary: false,
+        content: Some(body),
+        image_base64: None,
+        image_mime: None,
+        truncation: Some(truncation),
+        token_cost,
+        audit: MentionAudit {
+            phase: "B".to_string(),
+            tokens_before_truncate: tokens_before,
+            error: None,
+        },
+    }
+}
+
+fn apply_filter(input: &str, level: FilterLevel) -> String {
+    match level {
+        FilterLevel::None => NoFilter.apply(input),
+        FilterLevel::Minimal => MinimalFilter.apply(input),
+        FilterLevel::Aggressive => AggressiveFilter.apply(input),
+    }
+}
+
+/// Slice `input` to the inclusive 1-based line range `[start, end]`. Out-
+/// of-range `start` past EOF yields an empty string; `end` is clamped to
+/// the last line. We work in `split('\n')` and re-join so the trailing
+/// newline behaviour matches the rest of the budget pipeline.
+fn slice_lines(input: &str, start: u32, end: u32) -> String {
+    let lines: Vec<&str> = input.split('\n').collect();
+    let s = (start as usize).saturating_sub(1).min(lines.len());
+    let e = (end as usize).min(lines.len());
+    if s >= e {
+        return String::new();
+    }
+    lines[s..e].join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// Dedup-by-turn cache
+// ---------------------------------------------------------------------------
+
+/// Lightweight per-turn memoization of `resolve_mentions`.
+///
+/// Hosts create one `MentionResolverCache` at the start of a turn, call
+/// `resolve_cached` for each path, and drop the cache at the end of the
+/// turn. `turn_id == 0` disables caching (every call hits the resolver).
+///
+/// The cache is **not** thread-safe — wrap in `Mutex` if multiple agents
+/// share it. Phase D will add a `DashMap` if the trait surface demands it.
+#[derive(Debug, Default)]
+pub struct MentionResolverCache {
+    /// Per-turn entries. Keyed by absolute path so two relative paths
+    /// pointing at the same file dedup correctly.
+    by_turn: HashMap<u64, HashMap<PathBuf, ResolvedMention>>,
+    /// Most recent `turn_id` passed to `resolve_cached`. Used as a
+    /// micro-optimization so the common case ("still in turn N") skips
+    /// a `HashMap::get` on `by_turn`.
+    last_turn: u64,
+}
+
+impl MentionResolverCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resolve `path` (or return the cached `ResolvedMention` if `path`
+    /// was already resolved in this `turn_id`).
+    ///
+    /// `opts` is *ignored* on a cache hit — the cached result was built
+    /// with whatever options were used the first time. Hosts that need
+    /// option-aware dedup should pass a synthetic cache key (e.g. hash
+    /// of `opts`) instead of using this convenience method.
+    pub fn resolve_cached(
+        &mut self,
+        path: &Path,
+        opts: &ResolveOptions,
+        turn_id: u64,
+    ) -> ResolvedMention {
+        if turn_id == 0 {
+            return resolve_one(path, opts);
+        }
+
+        if self.last_turn != turn_id {
+            // Stale turn: clear and re-key.
+            self.by_turn.clear();
+            self.last_turn = turn_id;
+        }
+
+        let bucket = self.by_turn.entry(turn_id).or_default();
+
+        // Canonicalize so a path string like "./foo.rs" and "/abs/foo.rs"
+        // dedup correctly. If canonicalize fails, use the path verbatim
+        // and proceed; the resolver itself will also try to canonicalize.
+        let key = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+
+        if let Some(hit) = bucket.get(&key) {
+            return hit.clone();
+        }
+
+        let resolved = resolve_one(&key, opts);
+        bucket.insert(key, resolved.clone());
+        resolved
+    }
+
+    /// Number of paths currently memoized across all known turns.
+    /// Test-only.
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.by_turn.values().map(|b| b.len()).sum()
+    }
+
+    /// Drop all cached entries. Call between turns if you'd rather not
+    /// rely on the implicit clear in `resolve_cached`.
+    pub fn clear(&mut self) {
+        self.by_turn.clear();
+        self.last_turn = 0;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    /// Build a temp dir containing the requested files. Returns the
+    /// directory handle and a vec of absolute paths matching `files`.
+    fn write_files(spec: &[(&str, &[u8])]) -> (tempfile::TempDir, Vec<PathBuf>) {
+        let dir = tempdir().expect("tempdir");
+        let mut paths = Vec::new();
+        for (name, body) in spec {
+            let p = dir.path().join(name);
+            if let Some(parent) = p.parent() {
+                fs::create_dir_all(parent).expect("mkdir -p");
+            }
+            let mut f = fs::File::create(&p).expect("create");
+            f.write_all(body).expect("write");
+            paths.push(p);
+        }
+        (dir, paths)
+    }
+
+    #[test]
+    fn text_file_resolved_with_content_and_token_cost() {
+        let (dir, paths) = write_files(&[("hello.rs", b"fn main() {}\n")]);
+        let opts = ResolveOptions::default();
+        let out = resolve_mentions(&paths, &opts);
+        assert_eq!(out.len(), 1);
+        let m = &out[0];
+        assert_eq!(m.kind, MentionKind::File);
+        assert!(!m.is_binary);
+        assert!(m.content.as_deref().unwrap().contains("fn main"));
+        assert!(m.token_cost > 0);
+        assert_eq!(m.audit.phase, "B");
+        // Token cost should equal estimate_tokens of the post-filter
+        // post-truncate body length.
+        let body = m.content.as_deref().unwrap();
+        assert_eq!(
+            m.token_cost as u64,
+            estimate_tokens(body.len() as u64)
+        );
+        // The path was canonicalized to an absolute path.
+        assert!(m.path.starts_with(dir.path()));
+    }
+
+    #[test]
+    fn binary_file_detected_content_none() {
+        // 0x00 byte in the first 8KB => binary.
+        let (dir, paths) = write_files(&[("blob.bin", &[0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9])]);
+        let opts = ResolveOptions::default();
+        let out = resolve_mentions(&paths, &opts);
+        let m = &out[0];
+        assert_eq!(m.kind, MentionKind::File);
+        assert!(m.is_binary);
+        assert!(m.content.is_none());
+        assert_eq!(m.token_cost, 0);
+        assert!(m.audit.error.is_none());
+        assert!(m.path.starts_with(dir.path()));
+    }
+
+    #[test]
+    fn image_marked_image_with_mime() {
+        let (dir, paths) = write_files(&[("logo.png", b"\x89PNG\r\n\x1a\n")]);
+        let opts = ResolveOptions::default();
+        let out = resolve_mentions(&paths, &opts);
+        let m = &out[0];
+        assert_eq!(m.kind, MentionKind::Image);
+        assert_eq!(m.image_mime.as_deref(), Some("image/png"));
+        assert!(m.is_binary);
+        assert!(m.content.is_none());
+        assert_eq!(m.image_base64, None);
+        assert!(m.path.starts_with(dir.path()));
+    }
+
+    #[test]
+    fn jpeg_mime_jpeg() {
+        let (_dir, paths) = write_files(&[("a.jpg", b"not really a jpg")]);
+        let out = resolve_mentions(&paths, &ResolveOptions::default());
+        assert_eq!(out[0].image_mime.as_deref(), Some("image/jpeg"));
+    }
+
+    #[test]
+    fn jpeg_extension_uppercase_mime_jpeg() {
+        let (_dir, paths) = write_files(&[("a.JPEG", b"x")]);
+        let out = resolve_mentions(&paths, &ResolveOptions::default());
+        assert_eq!(out[0].image_mime.as_deref(), Some("image/jpeg"));
+    }
+
+    #[test]
+    fn webp_mime() {
+        let (_dir, paths) = write_files(&[("a.webp", b"x")]);
+        let out = resolve_mentions(&paths, &ResolveOptions::default());
+        assert_eq!(out[0].image_mime.as_deref(), Some("image/webp"));
+    }
+
+    #[test]
+    fn directory_resolved_with_listing() {
+        let dir = tempdir().expect("tempdir");
+        for n in ["a.rs", "b.rs", "c.txt"] {
+            fs::write(dir.path().join(n), b"x").unwrap();
+        }
+        let p = dir.path().to_path_buf();
+        let out = resolve_mentions(&[p.clone()], &ResolveOptions::default());
+        let m = &out[0];
+        assert_eq!(m.kind, MentionKind::Directory);
+        let body = m.content.as_deref().expect("dir body");
+        assert!(body.contains("a.rs"));
+        assert!(body.contains("b.rs"));
+        assert!(body.contains("c.txt"));
+        assert!(m.token_cost > 0);
+    }
+
+    #[test]
+    fn line_range_applied_before_truncation() {
+        let body: String = (1..=20).map(|i| format!("line {i}\n")).collect();
+        let (dir, paths) = write_files(&[("x.txt", body.as_bytes())]);
+        let opts = ResolveOptions {
+            line_range: Some((5, 7)),
+            ..ResolveOptions::default()
+        };
+        let out = resolve_mentions(&paths, &opts);
+        let m = &out[0];
+        let c = m.content.as_deref().unwrap();
+        assert!(c.contains("line 5"));
+        assert!(c.contains("line 6"));
+        assert!(c.contains("line 7"));
+        assert!(!c.contains("line 4"));
+        assert!(!c.contains("line 8"));
+        assert_eq!(m.line_range, Some((5, 7)));
+        assert!(m.path.starts_with(dir.path()));
+    }
+
+    #[test]
+    fn smart_truncate_applied_when_content_exceeds_budget() {
+        // Build a 200-line file; ask for a budget that fits ~20 lines.
+        let body: String = (1..=200).map(|i| format!("line {i}\n")).collect();
+        let (_dir, paths) = write_files(&[("big.txt", body.as_bytes())]);
+        // 200 bytes total budget fits a handful of lines, well under
+        // 200 lines. The footer should be present.
+        let opts = ResolveOptions {
+            max_tokens: 10, // 40 bytes via tokens_to_bytes
+            ..ResolveOptions::default()
+        };
+        let out = resolve_mentions(&paths, &opts);
+        let m = &out[0];
+        let c = m.content.as_deref().unwrap();
+        assert!(c.contains("more lines]"), "expected truncation footer in: {c}");
+        let trunc = m.truncation.as_ref().expect("truncation outcome");
+        assert!(trunc.dropped_lines > 0);
+    }
+
+    #[test]
+    fn no_truncation_when_content_fits() {
+        let (_dir, paths) = write_files(&[("small.txt", b"hello\n")]);
+        let opts = ResolveOptions {
+            max_tokens: 50_000,
+            ..ResolveOptions::default()
+        };
+        let out = resolve_mentions(&paths, &opts);
+        let m = &out[0];
+        let trunc = m.truncation.as_ref().unwrap();
+        assert_eq!(trunc.dropped_lines, 0);
+    }
+
+    #[test]
+    fn nonexistent_file_returns_error_audit() {
+        let bogus = PathBuf::from("/this/path/does/not/exist/abcxyz.rs");
+        let out = resolve_mentions(&[bogus.clone()], &ResolveOptions::default());
+        let m = &out[0];
+        assert_eq!(m.kind, MentionKind::File);
+        assert!(m.content.is_none());
+        assert!(m.audit.error.is_some());
+        // We record the input path verbatim when canonicalize fails.
+        assert_eq!(m.path, bogus);
+    }
+
+    #[test]
+    fn dedup_same_turn_returns_cached_result() {
+        let (_dir, paths) = write_files(&[("a.rs", b"fn a() {}\n")]);
+        let p = paths[0].clone();
+        let opts = ResolveOptions::default();
+        let mut cache = MentionResolverCache::new();
+
+        let r1 = cache.resolve_cached(&p, &opts, 42);
+        let r2 = cache.resolve_cached(&p, &opts, 42);
+        // The two results should be byte-identical (cache hit clones).
+        assert_eq!(r1.path, r2.path);
+        assert_eq!(r1.content, r2.content);
+        assert_eq!(r1.token_cost, r2.token_cost);
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn dedup_turn_zero_disables_cache() {
+        let (_dir, paths) = write_files(&[("a.rs", b"fn a() {}\n")]);
+        let p = paths[0].clone();
+        let opts = ResolveOptions::default();
+        let mut cache = MentionResolverCache::new();
+        let _ = cache.resolve_cached(&p, &opts, 0);
+        let _ = cache.resolve_cached(&p, &opts, 0);
+        // turn_id == 0 must NOT populate the cache.
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn different_turns_do_not_share_cache() {
+        let (_dir, paths) = write_files(&[("a.rs", b"fn a() {}\n")]);
+        let p = paths[0].clone();
+        let opts = ResolveOptions::default();
+        let mut cache = MentionResolverCache::new();
+        let _ = cache.resolve_cached(&p, &opts, 1);
+        assert_eq!(cache.len(), 1);
+        // Switching turn_id drops the previous turn's bucket.
+        let _ = cache.resolve_cached(&p, &opts, 2);
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn filter_levels_change_output() {
+        // A Rust source file with a triple-slash doc comment, a regular
+        // line comment, and a block comment. Minimal keeps ///, strips //.
+        // Aggressive strips everything.
+        let body = b"/// keep me\n// strip me\n/* block */\nfn x() {}\n";
+        let (_dir, paths) = write_files(&[("x.rs", body)]);
+
+        let minimal = resolve_mentions(
+            &paths,
+            &ResolveOptions {
+                filter_level: FilterLevel::Minimal,
+                ..ResolveOptions::default()
+            },
+        );
+        let aggressive = resolve_mentions(
+            &paths,
+            &ResolveOptions {
+                filter_level: FilterLevel::Aggressive,
+                ..ResolveOptions::default()
+            },
+        );
+        let none = resolve_mentions(
+            &paths,
+            &ResolveOptions {
+                filter_level: FilterLevel::None,
+                ..ResolveOptions::default()
+            },
+        );
+
+        let m = minimal[0].content.as_deref().unwrap();
+        assert!(m.contains("/// keep me"), "minimal must keep doc: {m}");
+        assert!(!m.contains("strip me"), "minimal must strip // line: {m}");
+
+        let a = aggressive[0].content.as_deref().unwrap();
+        assert!(!a.contains("keep me"), "aggressive must strip /// doc: {a}");
+        assert!(!a.contains("block"), "aggressive must strip /* */: {a}");
+
+        let n = none[0].content.as_deref().unwrap();
+        assert!(n.contains("keep me"));
+        assert!(n.contains("strip me"));
+        assert!(n.contains("block"));
+    }
+
+    #[test]
+    fn nonexistent_directory_returns_error() {
+        let bogus = PathBuf::from("/no/such/dir/zzzqqq");
+        let out = resolve_mentions(&[bogus], &ResolveOptions::default());
+        // The canonicalize step fails before we ever get to the dir
+        // branch, so kind=File + audit.error is the contract.
+        let m = &out[0];
+        assert!(m.audit.error.is_some());
+    }
+
+    #[test]
+    fn binary_detection_probe_uses_first_8kb() {
+        // Place NUL only after the probe window: first 10KB are pure
+        // ASCII, then 4KB of zeros. The probe sees no NUL => treated as
+        // text, so the resolver opens it as text. This is the documented
+        // trade-off: cheap probe, possible false negative on huge files.
+        let mut body = vec![b'a'; 10 * 1024];
+        body.extend(std::iter::repeat(0u8).take(4 * 1024));
+        let (_dir, paths) = write_files(&[("tricky.bin", &body)]);
+        let out = resolve_mentions(&paths, &ResolveOptions::default());
+        let m = &out[0];
+        assert!(!m.is_binary, "binary detection must only look at first 8KB");
+        assert!(m.content.is_some());
+    }
+
+    #[test]
+    fn resolve_options_default_is_minimal_50k_tokens() {
+        let o = ResolveOptions::default();
+        assert_eq!(o.max_tokens, 50_000);
+        assert_eq!(o.filter_level, FilterLevel::Minimal);
+        assert_eq!(o.line_range, None);
+    }
+}

--- a/crates/ffs-engine/src/mention.rs
+++ b/crates/ffs-engine/src/mention.rs
@@ -225,9 +225,7 @@ fn resolve_one(path: &Path, opts: &ResolveOptions) -> ResolvedMention {
 
     // Regular file. Binary-detection probe first, then text path.
     match read_and_classify(&abs) {
-        ClassifiedFile::Text(content) => {
-            resolve_text(&abs, size, content, opts)
-        }
+        ClassifiedFile::Text(content) => resolve_text(&abs, size, content, opts),
         ClassifiedFile::Binary => ResolvedMention {
             path: abs,
             kind: MentionKind::File,
@@ -369,12 +367,7 @@ fn resolve_directory(path: &Path, metadata: &fs::Metadata) -> ResolvedMention {
     }
 }
 
-fn resolve_text(
-    path: &Path,
-    size: u64,
-    raw: String,
-    opts: &ResolveOptions,
-) -> ResolvedMention {
+fn resolve_text(path: &Path, size: u64, raw: String, opts: &ResolveOptions) -> ResolvedMention {
     // 1. Apply line range slice (1-based, inclusive on both ends).
     let sliced = match opts.line_range {
         Some((start, end)) if start > 0 => slice_lines(&raw, start, end),
@@ -559,10 +552,7 @@ mod tests {
         // Token cost should equal estimate_tokens of the post-filter
         // post-truncate body length.
         let body = m.content.as_deref().unwrap();
-        assert_eq!(
-            m.token_cost as u64,
-            estimate_tokens(body.len() as u64)
-        );
+        assert_eq!(m.token_cost as u64, estimate_tokens(body.len() as u64));
         // The path was canonicalized to an absolute path.
         assert!(m.path.starts_with(dir.path()));
     }
@@ -668,7 +658,10 @@ mod tests {
         let out = resolve_mentions(&paths, &opts);
         let m = &out[0];
         let c = m.content.as_deref().unwrap();
-        assert!(c.contains("more lines]"), "expected truncation footer in: {c}");
+        assert!(
+            c.contains("more lines]"),
+            "expected truncation footer in: {c}"
+        );
         let trunc = m.truncation.as_ref().expect("truncation outcome");
         assert!(trunc.dropped_lines > 0);
     }

--- a/crates/ffs-mcp/Cargo.toml
+++ b/crates/ffs-mcp/Cargo.toml
@@ -35,3 +35,6 @@ tracing = { workspace = true }
 git2 = { workspace = true }
 clap = { version = "4", features = ["derive", "env"] }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+

--- a/crates/ffs-mcp/src/main.rs
+++ b/crates/ffs-mcp/src/main.rs
@@ -9,6 +9,7 @@
 mod cursor;
 mod engine_tools;
 mod healthcheck;
+mod mention_tools;
 mod output;
 mod server;
 mod update_check;

--- a/crates/ffs-mcp/src/mention_tools.rs
+++ b/crates/ffs-mcp/src/mention_tools.rs
@@ -1,0 +1,245 @@
+//! Param shapes and a small in-process helper for the `ffs_mention_search`
+//! MCP tool. The handler itself lives in `server.rs` (it needs access to
+//! `FfsServer::picker`); this module keeps the schema and the JSON
+//! serialization in one place so the C ABI surface and the MCP surface
+//! can share the resolved-payload shape.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use ffs_budget::FilterLevel;
+use ffs_engine::mention::{resolve_mentions, ResolveOptions, ResolvedMention};
+use serde::Serialize;
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct MentionSearchParams {
+    /// Input string. Split on whitespace; each token becomes a substring
+    /// candidate query against the workspace, then resolved by Phase B.
+    pub input: String,
+    /// Maximum tokens of body allowed per resolved mention (default 50_000,
+    /// mirrors `ResolveOptions::default`).
+    #[serde(rename = "maxTokens")]
+    pub max_tokens: Option<f64>,
+    /// Optional line-range slice applied before `smart_truncate`. Two
+    /// 1-based line numbers, inclusive.
+    #[serde(rename = "lineRange")]
+    pub line_range: Option<Vec<f64>>,
+    /// Filter intensity: `"none"`, `"minimal"` (default), or `"aggressive"`.
+    #[serde(rename = "filterLevel")]
+    pub filter_level: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MentionSearchOutput {
+    pub input: String,
+    pub candidates: Vec<String>,
+    pub total_candidates: usize,
+    pub mentions: Vec<ResolvedMention>,
+    pub schema: &'static str,
+}
+
+/// Build the `ResolveOptions` from a `MentionSearchParams`. Pulled out of
+/// the handler so the test in `mod tests` can exercise the conversion
+/// without going through the full MCP plumbing.
+pub fn build_resolve_options(
+    max_tokens: Option<f64>,
+    line_range: Option<Vec<f64>>,
+    filter_level: Option<&str>,
+) -> ResolveOptions {
+    let max_tokens = max_tokens
+        .filter(|v| v.is_finite() && *v > 0.0)
+        .map(|v| v.round() as u32)
+        .unwrap_or(50_000);
+    let filter_level = match filter_level {
+        Some("none") => FilterLevel::None,
+        Some("aggressive") => FilterLevel::Aggressive,
+        _ => FilterLevel::Minimal,
+    };
+    let line_range = line_range.and_then(|v| {
+        if v.len() == 2 {
+            let s = v[0].round().max(1.0) as u32;
+            let e = v[1].round().max(s as f64) as u32;
+            Some((s, e))
+        } else {
+            None
+        }
+    });
+    ResolveOptions {
+        max_tokens,
+        filter_level,
+        line_range,
+    }
+}
+
+/// Run the mention pipeline: walk `root`, substring-filter by the
+/// whitespace-separated tokens of `input`, hand the candidates to the
+/// Phase B resolver, and serialize the result. The function is shared
+/// between the MCP handler and the tests.
+pub fn run_mention_pipeline(input: &str, root: &Path, opts: &ResolveOptions) -> MentionSearchOutput {
+    let candidates = collect_candidates(root, input);
+    let paths: Vec<PathBuf> = candidates.iter().map(PathBuf::from).collect();
+    let mentions = resolve_mentions(&paths, opts);
+    MentionSearchOutput {
+        input: input.to_string(),
+        total_candidates: candidates.len(),
+        candidates,
+        mentions,
+        schema: "v1",
+    }
+}
+
+fn collect_candidates(root: &Path, input: &str) -> Vec<String> {
+    use std::collections::HashSet;
+    let tokens: Vec<&str> = input
+        .split_whitespace()
+        .filter(|t| !t.is_empty())
+        .collect();
+    if tokens.is_empty() {
+        return Vec::new();
+    }
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<String> = Vec::new();
+    for entry in walk_files_simple(root) {
+        let Some(s) = entry.to_str() else { continue };
+        if tokens.iter().any(|t| s.contains(t)) && seen.insert(s.to_string()) {
+            out.push(s.to_string());
+        }
+    }
+    out.sort();
+    out
+}
+
+fn walk_files_simple(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let walker = ignore::WalkBuilder::new(root)
+        .standard_filters(true)
+        .follow_links(false)
+        .threads(2)
+        .build();
+    for entry in walker.flatten() {
+        if entry.file_type().is_some_and(|t| t.is_file()) {
+            out.push(entry.into_path());
+        }
+    }
+    out
+}
+
+/// Serialize an `Arc<str>`-like owned `MentionSearchOutput` to a JSON
+/// string. Returns an error string on failure so the MCP handler can wrap
+/// it in `ErrorData` without unwrapping the JSON path.
+pub fn output_to_json(out: &MentionSearchOutput) -> Result<String, String> {
+    serde_json::to_string(out).map_err(|e| format!("serialize MentionSearchOutput: {e}"))
+}
+
+// Suppress dead-code warnings for items kept for the forthcoming Phase D
+// provider hookup (mentioned in the v2 plan).
+#[allow(dead_code)]
+fn _phase_d_anchor(_: Arc<()>) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    fn write_files(dir: &Path) {
+        std::fs::write(dir.join("alpha.rs"), b"fn alpha() {}\n").unwrap();
+        std::fs::write(dir.join("beta.rs"), b"fn beta() {}\n").unwrap();
+        std::fs::create_dir_all(dir.join("nested")).unwrap();
+        std::fs::write(dir.join("nested/gamma.rs"), b"fn gamma() {}\n").unwrap();
+    }
+
+    #[test]
+    fn params_parse_minimal() {
+        let p: MentionSearchParams = serde_json::from_value(json!({ "input": "alpha" })).unwrap();
+        assert_eq!(p.input, "alpha");
+        assert!(p.max_tokens.is_none());
+        assert!(p.line_range.is_none());
+        assert!(p.filter_level.is_none());
+    }
+
+    #[test]
+    fn params_parse_full() {
+        let p: MentionSearchParams = serde_json::from_value(json!({
+            "input": "alpha",
+            "maxTokens": 2500.0,
+            "lineRange": [10.0, 20.0],
+            "filterLevel": "aggressive",
+        }))
+        .unwrap();
+        assert_eq!(p.max_tokens, Some(2500.0));
+        assert_eq!(p.line_range.as_ref().unwrap().len(), 2);
+        assert_eq!(p.filter_level.as_deref(), Some("aggressive"));
+    }
+
+    #[test]
+    fn params_rejects_missing_input() {
+        let r: Result<MentionSearchParams, _> =
+            serde_json::from_value(json!({ "maxTokens": 1.0 }));
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn build_resolve_options_defaults() {
+        let o = build_resolve_options(None, None, None);
+        assert_eq!(o.max_tokens, 50_000);
+        assert_eq!(o.filter_level, FilterLevel::Minimal);
+        assert_eq!(o.line_range, None);
+    }
+
+    #[test]
+    fn build_resolve_options_handles_zero_max_tokens() {
+        // 0 must NOT become 0 tokens in the budget; falls back to default.
+        let o = build_resolve_options(Some(0.0), None, None);
+        assert_eq!(o.max_tokens, 50_000);
+    }
+
+    #[test]
+    fn build_resolve_options_filter_levels() {
+        assert_eq!(
+            build_resolve_options(None, None, Some("none")).filter_level,
+            FilterLevel::None
+        );
+        assert_eq!(
+            build_resolve_options(None, None, Some("aggressive")).filter_level,
+            FilterLevel::Aggressive
+        );
+        assert_eq!(
+            build_resolve_options(None, None, Some("garbage")).filter_level,
+            FilterLevel::Minimal
+        );
+    }
+
+    #[test]
+    fn run_mention_pipeline_returns_resolved_mentions() {
+        let td = tempdir().unwrap();
+        write_files(td.path());
+        let opts = build_resolve_options(Some(1000.0), None, None);
+        let out = run_mention_pipeline("alpha", td.path(), &opts);
+        assert_eq!(out.total_candidates, 1);
+        assert!(out.mentions[0].content.as_deref().unwrap().contains("alpha"));
+    }
+
+    #[test]
+    fn run_mention_pipeline_empty_input() {
+        let td = tempdir().unwrap();
+        write_files(td.path());
+        let opts = build_resolve_options(None, None, None);
+        let out = run_mention_pipeline("   ", td.path(), &opts);
+        assert_eq!(out.total_candidates, 0);
+        assert!(out.mentions.is_empty());
+    }
+
+    #[test]
+    fn output_to_json_round_trips() {
+        let td = tempdir().unwrap();
+        write_files(td.path());
+        let opts = build_resolve_options(None, None, None);
+        let out = run_mention_pipeline("alpha", td.path(), &opts);
+        let json = output_to_json(&out).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed["candidates"].is_array());
+        assert!(parsed["mentions"].is_array());
+        assert_eq!(parsed["schema"], "v1");
+    }
+}

--- a/crates/ffs-mcp/src/server.rs
+++ b/crates/ffs-mcp/src/server.rs
@@ -1098,6 +1098,31 @@ impl FfsServer {
             .map_err(|e| ErrorData::internal_error(format!("ffs overview failed: {e}"), None))?;
         Ok(CallToolResult::success(vec![Content::text(text)]))
     }
+
+    /// Phase C @-mention surface. Resolves a free-form input string into a
+    /// JSON array of `ResolvedMention` payloads, one per substring-matched
+    /// file. Mirrors `ffs mention-search` on the CLI and
+    /// `ffs_mention_search_json` in the C ABI. Phase D will add provider
+    /// hooks; for now every mention resolves to a local file/dir/image.
+    #[tool(
+        name = "ffs_mention_search",
+        description = "Resolve a @-mention-style input against the workspace and return a JSON array of `ResolvedMention` payloads (path, kind, content, token cost, audit). Mirrors `ffs mention-search` (CLI) and `ffs_mention_search_json` (C ABI). Use when an agent receives a mention string and needs the underlying file contents token-budgeted for an LLM context."
+    )]
+    fn ffs_mention_search(
+        &self,
+        Parameters(params): Parameters<crate::mention_tools::MentionSearchParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let root = self.picker_base_path()?;
+        let opts = crate::mention_tools::build_resolve_options(
+            params.max_tokens,
+            params.line_range,
+            params.filter_level.as_deref(),
+        );
+        let out = crate::mention_tools::run_mention_pipeline(&params.input, &root, &opts);
+        let json = crate::mention_tools::output_to_json(&out)
+            .map_err(|e| ErrorData::internal_error(e, None))?;
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
 }
 
 impl FfsServer {
@@ -1276,5 +1301,28 @@ mod tests {
         let via_pattern: FindFilesParams =
             serde_json::from_str(r#"{"pattern":"foo"}"#).expect("pattern alias");
         assert_eq!(via_pattern.query, "foo");
+    }
+
+    /// Smoke test: confirm the `ffs_mention_search` tool is wired into the
+    /// `#[tool_router]` router. The macro-generated `tool_router` field
+    /// carries an `attr(...)` map; we just check the tool name is present
+    /// so a future refactor that drops the `#[tool]` attribute fails CI
+    /// instead of silently shipping a broken MCP server.
+    #[test]
+    fn ffs_mention_search_tool_is_registered() {
+        let server = FfsServer::new(
+            ffs::SharedFilePicker::default(),
+            ffs::SharedFrecency::default(),
+        );
+        let tools: Vec<_> = server
+            .tool_router
+            .list_all()
+            .into_iter()
+            .map(|t| t.name.to_string())
+            .collect();
+        assert!(
+            tools.iter().any(|n| n == "ffs_mention_search"),
+            "ffs_mention_search not registered. Tools: {tools:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Ships **Phases B, C, and D** of the unified `@`-mention system in a single stacked branch. This PR is **self-contained** but depends on PR #41 (Phase A) being merged into main first — the `pub mod mention;` line added to ffs-core's `lib.rs` references the Phase A `mention/` module which lives in #41.

**Contains 4 commits** (chronological):
1. `feat(ffs-engine): add @-mention ResolvedMention + dedup cache (Phase B)`
2. `feat(surfaces): add ffs mention CLI + C ABI JSON + MCP tool (Phase C)`
3. `feat(ffs-core): scaffold MentionProvider trait + ProviderRegistry (Phase D)`
4. `style: apply rustfmt to Phase B/C/D modules`

**Total**: 15 files, 2249 insertions.

## Phase B — Resolve (`crates/ffs-engine/src/mention.rs`)

- `ResolvedMention { path, kind, line_range, content/image_base64/mime, truncation, token_cost, audit }`
- `resolve_mentions(paths, opts) -> Vec<ResolvedMention>` — text/binary/image/dir detection, `smart_truncate`, `MinimalFilter`, line range
- `MentionResolverCache` — dedup-by-turn, keyed by `(path, turn_id)`
- 35 unit tests in ffs-engine, 0 regressions
- Lives in **ffs-engine** (not ffs-core) per the v2 plan

## Phase C — Surfaces

### CLI: `ffs mention-search`
- `crates/ffs-cli/src/commands/mention.rs` (NEW)
- Wired into `Command` enum as `Mention(commands::mention::Args)`
- Flags: `--format {json,text}` (default json), `--cursor <usize>`, `--max-tokens <u32>`
- Reads input, calls `ffs_engine::mention::resolve_mentions()`, prints JSON or text

### C ABI: `ffs_mention_search_json`
- `crates/ffs-c/src/lib.rs` adds the export
- `crates/ffs-c/include/ffs.h` adds the declaration
- Signature: `FfsResult *ffs_mention_search_json(handle, input, cursor, options_json)`
- JSON-input options (max_tokens, filter_level), JSON-output results
- Reuses existing `FfsResult` / `ffs_free_result` ABI

### MCP: `ffs_mention_search`
- `crates/ffs-mcp/src/mention_tools.rs` (NEW) — `MentionSearchParams`
- `crates/ffs-mcp/src/server.rs` — new `#[tool(name = "ffs_mention_search")]` method
- Returns resolved mentions as text content

## Phase D — Extensibility

- `crates/ffs-core/src/mention/{mod,provider}.rs` (NEW module)
- `MentionProvider` trait (Send + Sync, FFI-safe, no generics)
- `ExternalMentionCandidate` + `ExternalResolveResult` enum (Agent/Tool/Skill/Image/McpResource/Other)
- `ProviderRegistry` — `register` / `get` / `list_kinds` over `HashMap<&'static str, Arc<dyn MentionProvider>>`
- `is_local() -> bool` per oh-my-pi's "fast and local" invariant
- 19 unit tests in ffs-search
- 100% additive, scaffolds the trait for host-registered external kinds (jcode's `agent`/`skill`, Claude Code's `tool`/`mcp_resource`, etc.)

## Validation

- `cargo test -p ffs-search --lib mention` — 19 passed
- `cargo test -p ffs-engine --lib` — 35 passed
- `cargo clippy -p ffs-search --lib --no-deps -- -D warnings` — clean
- `cargo clippy -p ffs-engine --lib --no-deps -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- 0 regressions in existing tests

## Dependency

⚠️ **This PR depends on PR #41 (Phase A) being merged first.** The Phase D commit adds `pub mod mention;` to ffs-core's `lib.rs` which references the `mention/` module shipped in #41. If #41 is not yet on main, this branch will fail to compile when rebased.

After this PR lands, a **follow-up PR** will integrate `MentionResolver::with_provider(Arc<dyn MentionProvider>)` to wire Phase D's provider registry into Phase A's resolver — closing the @-mention system loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)