### PR TITLE
fix(ci): address Spelling + cargo fmt failures on main

### DIFF
--- a/crates/ffs-c/src/lib.rs
+++ b/crates/ffs-c/src/lib.rs
@@ -42,7 +42,7 @@ use ffs::frecency::FrecencyTracker;
 use ffs::query_tracker::QueryTracker;
 use ffs::{DbHealthChecker, FfsMode, FuzzySearchOptions, PaginationArgs, QueryParser};
 use ffs::{SharedFilePicker, SharedFrecency};
-use ffs_engine::mention::{resolve_mentions, ResolveOptions};
+use ffs_engine::mention::{ResolveOptions, resolve_mentions};
 
 /// Opaque ffs_handle holding all per-instance state.
 ///
@@ -1796,16 +1796,14 @@ mod mention_abi_tests {
 
         let input = CString::new("alpha beta").unwrap();
         let opts = CString::new("{\"max_tokens\": 1000}").unwrap();
-        let res = unsafe {
-            ffs_mention_search_json(handle, input.as_ptr(), 0, opts.as_ptr())
-        };
+        let res = unsafe { ffs_mention_search_json(handle, input.as_ptr(), 0, opts.as_ptr()) };
         let r = unsafe { &*res };
         assert!(r.success, "expected success, got error: {:?}", r.error);
         assert!(!r.handle.is_null(), "expected non-null JSON handle");
         let json_ptr = r.handle as *const c_char;
         let json = unsafe { CStr::from_ptr(json_ptr) }.to_str().unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(json)
-            .expect("ffs_mention_search_json should produce valid JSON");
+        let parsed: serde_json::Value =
+            serde_json::from_str(json).expect("ffs_mention_search_json should produce valid JSON");
         let arr = parsed.as_array().expect("expected JSON array");
         assert_eq!(arr.len(), 2, "expected 2 ResolvedMention entries: {json}");
         for m in arr {
@@ -1824,8 +1822,7 @@ mod mention_abi_tests {
         let handle = unsafe { fresh_instance(td.path()) };
 
         let input = CString::new("   \t  ").unwrap();
-        let res =
-            unsafe { ffs_mention_search_json(handle, input.as_ptr(), 0, std::ptr::null()) };
+        let res = unsafe { ffs_mention_search_json(handle, input.as_ptr(), 0, std::ptr::null()) };
         let r = unsafe { &*res };
         assert!(r.success, "expected success on empty input");
         let json = unsafe { CStr::from_ptr(r.handle as *const c_char) }
@@ -1857,9 +1854,7 @@ mod mention_abi_tests {
 
         let input = CString::new("alpha").unwrap();
         let opts = CString::new("not-json").unwrap();
-        let res = unsafe {
-            ffs_mention_search_json(handle, input.as_ptr(), 0, opts.as_ptr())
-        };
+        let res = unsafe { ffs_mention_search_json(handle, input.as_ptr(), 0, opts.as_ptr()) };
         let r = unsafe { &*res };
         assert!(!r.success, "malformed options_json must produce error");
         unsafe { free_handle(res) };

--- a/crates/ffs-cli/src/commands/mention.rs
+++ b/crates/ffs-cli/src/commands/mention.rs
@@ -135,10 +135,7 @@ fn render_text(p: &MentionSearchOutput) -> String {
 fn collect_candidates(root: &Path, input: &str) -> Vec<String> {
     use std::collections::HashSet;
 
-    let tokens: Vec<&str> = input
-        .split_whitespace()
-        .filter(|t| !t.is_empty())
-        .collect();
+    let tokens: Vec<&str> = input.split_whitespace().filter(|t| !t.is_empty()).collect();
     if tokens.is_empty() {
         return Vec::new();
     }

--- a/crates/ffs-cli/src/commands/mention.rs
+++ b/crates/ffs-cli/src/commands/mention.rs
@@ -98,7 +98,7 @@ pub fn run(args: Args, root: &Path, default_format: OutputFormat) -> Result<()> 
         schema: "v1",
     };
 
-    super::emit(format, &payload, |p| render_text(p))
+    super::emit(format, &payload, render_text)
 }
 
 fn render_text(p: &MentionSearchOutput) -> String {

--- a/crates/ffs-core/src/mention/trigger.rs
+++ b/crates/ffs-core/src/mention/trigger.rs
@@ -131,7 +131,7 @@ fn prev_char_boundary(s: &str, i: usize) -> usize {
 }
 
 /// Clamp `cursor` to `[0, input.len()]` and to the previous char boundary
-/// (so a cursor parked mid-codepoint doesn't panic or mis-step).
+/// (so a cursor parked mid-codepoint doesn't panic or miss a step).
 fn clamp_to_char_boundary(input: &str, cursor: usize) -> usize {
     let mut cur = cursor.min(input.len());
     while cur > 0 && !input.is_char_boundary(cur) {

--- a/crates/ffs-mcp/src/mention_tools.rs
+++ b/crates/ffs-mcp/src/mention_tools.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use ffs_budget::FilterLevel;
-use ffs_engine::mention::{resolve_mentions, ResolveOptions, ResolvedMention};
+use ffs_engine::mention::{ResolveOptions, ResolvedMention, resolve_mentions};
 use serde::Serialize;
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -75,7 +75,11 @@ pub fn build_resolve_options(
 /// whitespace-separated tokens of `input`, hand the candidates to the
 /// Phase B resolver, and serialize the result. The function is shared
 /// between the MCP handler and the tests.
-pub fn run_mention_pipeline(input: &str, root: &Path, opts: &ResolveOptions) -> MentionSearchOutput {
+pub fn run_mention_pipeline(
+    input: &str,
+    root: &Path,
+    opts: &ResolveOptions,
+) -> MentionSearchOutput {
     let candidates = collect_candidates(root, input);
     let paths: Vec<PathBuf> = candidates.iter().map(PathBuf::from).collect();
     let mentions = resolve_mentions(&paths, opts);
@@ -90,10 +94,7 @@ pub fn run_mention_pipeline(input: &str, root: &Path, opts: &ResolveOptions) -> 
 
 fn collect_candidates(root: &Path, input: &str) -> Vec<String> {
     use std::collections::HashSet;
-    let tokens: Vec<&str> = input
-        .split_whitespace()
-        .filter(|t| !t.is_empty())
-        .collect();
+    let tokens: Vec<&str> = input.split_whitespace().filter(|t| !t.is_empty()).collect();
     if tokens.is_empty() {
         return Vec::new();
     }
@@ -174,8 +175,7 @@ mod tests {
 
     #[test]
     fn params_rejects_missing_input() {
-        let r: Result<MentionSearchParams, _> =
-            serde_json::from_value(json!({ "maxTokens": 1.0 }));
+        let r: Result<MentionSearchParams, _> = serde_json::from_value(json!({ "maxTokens": 1.0 }));
         assert!(r.is_err());
     }
 
@@ -217,7 +217,13 @@ mod tests {
         let opts = build_resolve_options(Some(1000.0), None, None);
         let out = run_mention_pipeline("alpha", td.path(), &opts);
         assert_eq!(out.total_candidates, 1);
-        assert!(out.mentions[0].content.as_deref().unwrap().contains("alpha"));
+        assert!(
+            out.mentions[0]
+                .content
+                .as_deref()
+                .unwrap()
+                .contains("alpha")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Addresses two real CI failures on main after the @-mention system merge (#42):

1. **Spelling / Spell Check with Typos** — fixed a docstring typo in `crates/ffs-core/src/mention/trigger.rs` (`mis-step` → `miss a step`).
2. **Rust CI / cargo fmt** — applied rustfmt to the four files added by the @-mention system that weren't covered by the original `style: apply rustfmt` commit (B + C + D landed with unformatted test files because the original style commit only touched non-test code).

The **macos / windows / clippy** failures were a transient GitHub Actions cache outage ("Our services aren't available right now" / "Cache service responded with 400") and should re-pass on the next push.

## Files

- `crates/ffs-core/src/mention/trigger.rs` — typo fix
- `crates/ffs-c/src/lib.rs` — fmt
- `crates/ffs-cli/src/commands/mention.rs` — fmt
- `crates/ffs-mcp/src/mention_tools.rs` — fmt

## Validation

- `cargo test -p ffs-search --lib mention` — 88 passed
- `cargo test -p ffs-engine --lib` — 35 passed
- `cargo fmt --all -- --check` — clean