### PR TITLE
fix(ffs-engine): canonicalize tempdir in mention tests for macOS

### DIFF
--- a/crates/ffs-engine/src/mention.rs
+++ b/crates/ffs-engine/src/mention.rs
@@ -537,6 +537,17 @@ mod tests {
         (dir, paths)
     }
 
+    /// Return the canonical (symlink-resolved) absolute path of a temp
+    /// dir. On macOS, `tempdir().path()` may be `/var/folders/...` which
+    /// is a symlink to `/private/var/folders/...`. `fs::canonicalize`
+    /// inside `resolve_mentions` resolves that symlink, so the path
+    /// returned in `ResolvedMention.path` is the canonical form. The
+    /// assertion `m.path.starts_with(dir.path())` would fail unless
+    /// we canonicalize `dir.path()` first.
+    fn canonical_dir(dir: &tempfile::TempDir) -> std::path::PathBuf {
+        fs::canonicalize(dir.path()).expect("canonicalize tempdir")
+    }
+
     #[test]
     fn text_file_resolved_with_content_and_token_cost() {
         let (dir, paths) = write_files(&[("hello.rs", b"fn main() {}\n")]);
@@ -554,7 +565,7 @@ mod tests {
         let body = m.content.as_deref().unwrap();
         assert_eq!(m.token_cost as u64, estimate_tokens(body.len() as u64));
         // The path was canonicalized to an absolute path.
-        assert!(m.path.starts_with(dir.path()));
+        assert!(m.path.starts_with(canonical_dir(&dir)));
     }
 
     #[test]
@@ -569,7 +580,7 @@ mod tests {
         assert!(m.content.is_none());
         assert_eq!(m.token_cost, 0);
         assert!(m.audit.error.is_none());
-        assert!(m.path.starts_with(dir.path()));
+        assert!(m.path.starts_with(canonical_dir(&dir)));
     }
 
     #[test]
@@ -583,7 +594,7 @@ mod tests {
         assert!(m.is_binary);
         assert!(m.content.is_none());
         assert_eq!(m.image_base64, None);
-        assert!(m.path.starts_with(dir.path()));
+        assert!(m.path.starts_with(canonical_dir(&dir)));
     }
 
     #[test]
@@ -641,7 +652,7 @@ mod tests {
         assert!(!c.contains("line 4"));
         assert!(!c.contains("line 8"));
         assert_eq!(m.line_range, Some((5, 7)));
-        assert!(m.path.starts_with(dir.path()));
+        assert!(m.path.starts_with(canonical_dir(&dir)));
     }
 
     #[test]


### PR DESCRIPTION
Fixes the 4 mention tests that panic on macOS in CI.

## Root cause

`tempdir().path()` on macOS returns a path with a symlink component (e.g. `/var/folders/...` is a symlink to `/private/var/folders/...`). `fs::canonicalize` inside `resolve_mentions` resolves that symlink, so `m.path` is the canonical form, but the test asserts `m.path.starts_with(dir.path())` — the non-canonical form — which fails.

## Fix

Add a small `canonical_dir()` helper that wraps `fs::canonicalize(dir.path())` and use it in the 4 affected assertions. Linux and Windows paths are unaffected (tempdir is the real path), macOS now passes.

## Affected tests
- `text_file_resolved_with_content_and_token_cost`
- `binary_file_detected_content_none`
- `image_marked_image_with_mime`
- `line_range_applied_before_truncation`

## Validation
- 18/18 `ffs-engine::mention` tests pass locally (was 14/18, 4 panic on macOS)
- 35/35 `ffs-engine` tests pass
- `cargo fmt --check`, `cargo clippy -- -D warnings` clean

## Diff
1 file, +15 / -4 (mention.rs).