### PR TITLE
fix(symbol): repair Verse definition spans truncated by empty indented_block

### DIFF
--- a/crates/ffs-cli/src/commands/callees_resolve.rs
+++ b/crates/ffs-cli/src/commands/callees_resolve.rs
@@ -62,6 +62,7 @@ fn node_is_call(node: Node) -> bool {
             | "new_expression"
             | "object_creation_expression"
             | "macro_invocation"
+            | "failable_call_expression"
             | "scoped_call"
             | "function_call"
     )
@@ -216,5 +217,18 @@ function outer() {
         assert!(names.contains("foo"), "got: {names:?}");
         assert!(names.contains("Bar"), "got: {names:?}");
         assert!(names.contains("qux"), "got: {names:?}");
+    }
+
+    #[test]
+    fn verse_member_calls_in_if_guard_body() {
+        let src = r#"BindPlots<private>() : void =
+    if (Sim := GetGameSim[]):
+        Plot.SetPlayerBasesSlot(Idx)
+        Comp.BindPlot(Plot)
+"#;
+        let names = collect_callees(src, Lang::Verse, 1, 4).expect("parsed");
+        assert!(names.contains("SetPlayerBasesSlot"), "got: {names:?}");
+        assert!(names.contains("BindPlot"), "got: {names:?}");
+        assert!(names.contains("GetGameSim"), "got: {names:?}");
     }
 }

--- a/crates/ffs-cli/src/commands/callees_resolve.rs
+++ b/crates/ffs-cli/src/commands/callees_resolve.rs
@@ -43,6 +43,20 @@ fn walk(node: Node, src: &[u8], start: u32, end: u32, out: &mut BTreeSet<String>
         }
     }
 
+    // Verse: `Comp.BindPlot(Plot)` often parses as sibling `member_access` +
+    // `parenthesized_expression` instead of a single `call_expression`.
+    if node.kind() == "member_access" && row >= start {
+        if let Some(next) = node.next_named_sibling() {
+            if next.kind() == "parenthesized_expression" {
+                if let Some(member) = node.child_by_field_name("member") {
+                    if let Some(name) = rightmost_name(member, src) {
+                        out.insert(name);
+                    }
+                }
+            }
+        }
+    }
+
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         walk(child, src, start, end, out);

--- a/crates/ffs-symbol/src/lib.rs
+++ b/crates/ffs-symbol/src/lib.rs
@@ -22,6 +22,7 @@ pub mod outline_cache;
 pub mod symbol_index;
 pub mod treesitter;
 pub mod types;
+mod verse_spans;
 
 pub use bloom::{BloomFilter, BloomFilterCache};
 pub use lang::{detect_file_type, package_root};

--- a/crates/ffs-symbol/src/outline.rs
+++ b/crates/ffs-symbol/src/outline.rs
@@ -8,6 +8,7 @@ use crate::treesitter::{
     is_elixir_definition, js_function_context_name, node_text_simple,
 };
 use crate::types::{Lang, OutlineEntry, OutlineKind};
+use crate::verse_spans::{verse_repair_end_line, verse_skip_spurious_definition};
 
 /// Map a [`Lang`] to its tree-sitter [`Language`] descriptor.
 pub fn outline_language(lang: Lang) -> Option<Language> {
@@ -70,6 +71,9 @@ fn walk_top_level(
 }
 
 fn node_to_entry(node: Node, lines: &[&str], content: &str, lang: Lang) -> Option<OutlineEntry> {
+    if lang == Lang::Verse && verse_skip_spurious_definition(node, lines) {
+        return None;
+    }
     let kind = outline_kind_for(node, lang)?;
 
     let name = match (lang, node.kind()) {
@@ -83,7 +87,12 @@ fn node_to_entry(node: Node, lines: &[&str], content: &str, lang: Lang) -> Optio
     };
 
     let start_line = node.start_position().row as u32 + 1;
-    let end_line = node.end_position().row as u32 + 1;
+    let ast_end = node.end_position().row as u32 + 1;
+    let end_line = if lang == Lang::Verse {
+        verse_repair_end_line(node.kind(), start_line, ast_end, lines)
+    } else {
+        ast_end
+    };
 
     let signature = extract_signature(node, lines);
 
@@ -504,5 +513,26 @@ RunExample<public>()<suspends>:void =
             entries.iter().any(|e| e.name == "RunExample"),
             "expected RunExample function"
         );
+    }
+
+    #[test]
+    fn verse_if_guard_function_outline_span() {
+        let code = r#"game_manager := class(creative_device):
+    BindBaseComponentPlots<private>() : void =
+        if (Sim := GetGameSim[]):
+            Plot.SetPlayerBasesSlot(Idx)
+    OnBegin() : void = {}
+"#;
+        let entries = get_outline_entries(code, Lang::Verse);
+        let bind = entries
+            .iter()
+            .find(|e| e.name == "BindBaseComponentPlots")
+            .expect("expected BindBaseComponentPlots");
+        assert!(
+            bind.end_line >= 4,
+            "outline end_line should cover if body, got {}",
+            bind.end_line
+        );
+        assert!(bind.end_line < 5, "should stop before OnBegin");
     }
 }

--- a/crates/ffs-symbol/src/outline.rs
+++ b/crates/ffs-symbol/src/outline.rs
@@ -349,21 +349,21 @@ fn extract_signature(node: Node, lines: &[&str]) -> Option<String> {
     None
 }
 
-fn find_outline_entry<'a>(entries: &'a [OutlineEntry], name: &str) -> Option<&'a OutlineEntry> {
-    for entry in entries {
-        if entry.name == name {
-            return Some(entry);
-        }
-        if let Some(found) = find_outline_entry(&entry.children, name) {
-            return Some(found);
-        }
-    }
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn find_outline_entry<'a>(entries: &'a [OutlineEntry], name: &str) -> Option<&'a OutlineEntry> {
+        for entry in entries {
+            if entry.name == name {
+                return Some(entry);
+            }
+            if let Some(found) = find_outline_entry(&entry.children, name) {
+                return Some(found);
+            }
+        }
+        None
+    }
 
     #[test]
     fn extracts_rust_function() {

--- a/crates/ffs-symbol/src/outline.rs
+++ b/crates/ffs-symbol/src/outline.rs
@@ -306,6 +306,8 @@ fn collect_children(
                 | "block"
                 | "field_declaration_list"
                 | "type_definition"
+                | "indented_block"
+                | "colon_block"
         ) {
             let mut inner = child.walk();
             for grand in child.children(&mut inner) {

--- a/crates/ffs-symbol/src/outline.rs
+++ b/crates/ffs-symbol/src/outline.rs
@@ -526,8 +526,9 @@ RunExample<public>()<suspends>:void =
         let entries = get_outline_entries(code, Lang::Verse);
         let bind = entries
             .iter()
-            .find(|e| e.name == "BindBaseComponentPlots")
-            .expect("expected BindBaseComponentPlots");
+            .find(|e| e.name == "game_manager")
+            .and_then(|class| class.children.iter().find(|e| e.name == "BindBaseComponentPlots"))
+            .expect("expected BindBaseComponentPlots under game_manager");
         assert!(
             bind.end_line >= 4,
             "outline end_line should cover if body, got {}",

--- a/crates/ffs-symbol/src/outline.rs
+++ b/crates/ffs-symbol/src/outline.rs
@@ -349,6 +349,18 @@ fn extract_signature(node: Node, lines: &[&str]) -> Option<String> {
     None
 }
 
+fn find_outline_entry<'a>(entries: &'a [OutlineEntry], name: &str) -> Option<&'a OutlineEntry> {
+    for entry in entries {
+        if entry.name == name {
+            return Some(entry);
+        }
+        if let Some(found) = find_outline_entry(&entry.children, name) {
+            return Some(found);
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -526,16 +538,8 @@ RunExample<public>()<suspends>:void =
     OnBegin() : void = {}
 "#;
         let entries = get_outline_entries(code, Lang::Verse);
-        let bind = entries
-            .iter()
-            .find(|e| e.name == "game_manager")
-            .and_then(|class| {
-                class
-                    .children
-                    .iter()
-                    .find(|e| e.name == "BindBaseComponentPlots")
-            })
-            .expect("expected BindBaseComponentPlots under game_manager");
+        let bind = find_outline_entry(&entries, "BindBaseComponentPlots")
+            .expect("expected BindBaseComponentPlots in outline");
         assert!(
             bind.end_line >= 4,
             "outline end_line should cover if body, got {}",

--- a/crates/ffs-symbol/src/outline.rs
+++ b/crates/ffs-symbol/src/outline.rs
@@ -527,7 +527,12 @@ RunExample<public>()<suspends>:void =
         let bind = entries
             .iter()
             .find(|e| e.name == "game_manager")
-            .and_then(|class| class.children.iter().find(|e| e.name == "BindBaseComponentPlots"))
+            .and_then(|class| {
+                class
+                    .children
+                    .iter()
+                    .find(|e| e.name == "BindBaseComponentPlots")
+            })
             .expect("expected BindBaseComponentPlots under game_manager");
         assert!(
             bind.end_line >= 4,

--- a/crates/ffs-symbol/src/symbol_index.rs
+++ b/crates/ffs-symbol/src/symbol_index.rs
@@ -451,7 +451,8 @@ mod tests {
         assert!(
             hits[0].end_line >= 5,
             "expected span through body lines, got end_line {} (start {})",
-            hits[0].end_line, hits[0].line
+            hits[0].end_line,
+            hits[0].line
         );
         assert!(
             hits[0].end_line < 6,

--- a/crates/ffs-symbol/src/symbol_index.rs
+++ b/crates/ffs-symbol/src/symbol_index.rs
@@ -430,24 +430,28 @@ mod tests {
 
     #[test]
     fn verse_function_span_covers_if_guard_body() {
-        let f = touch_file(
-            "game_manager := class(creative_device):\n\
-             BindBaseComponentPlots<private>() : void =\n\
-                 if (Sim := GetGameSim[]):\n\
-                     Plot.SetPlayerBasesSlot(Idx)\n\
-                     Comp.BindPlot(Plot)\n\
-             OnBegin() : void = {}\n",
-            "verse",
-        );
+        let content = r#"game_manager := class(creative_device):
+    BindBaseComponentPlots<private>() : void =
+        if (Sim := GetGameSim[]):
+            Plot.SetPlayerBasesSlot(Idx)
+            Comp.BindPlot(Plot)
+    OnBegin() : void = {}
+"#;
+        let f = touch_file(content, "verse");
         let idx = SymbolIndex::new();
         let mtime = std::fs::metadata(f.path()).unwrap().modified().unwrap();
-        idx.index_file(f.path(), mtime, &std::fs::read_to_string(f.path()).unwrap());
+        idx.index_file(f.path(), mtime, content);
         let hits = idx.lookup_exact("BindBaseComponentPlots");
         assert_eq!(hits.len(), 1, "expected BindBaseComponentPlots definition");
+        assert_eq!(
+            hits[0].line, 2,
+            "expected header line 2, got line {}",
+            hits[0].line
+        );
         assert!(
             hits[0].end_line >= 5,
-            "expected span through body lines, got end_line {}",
-            hits[0].end_line
+            "expected span through body lines, got end_line {} (start {})",
+            hits[0].end_line, hits[0].line
         );
         assert!(
             hits[0].end_line < 6,

--- a/crates/ffs-symbol/src/symbol_index.rs
+++ b/crates/ffs-symbol/src/symbol_index.rs
@@ -17,6 +17,7 @@ use crate::treesitter::{
     is_elixir_definition, DEFINITION_KINDS,
 };
 use crate::types::{FileType, Lang};
+use crate::verse_spans::{verse_repair_end_line, verse_skip_spurious_definition};
 
 /// One occurrence of a symbol definition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -300,11 +301,20 @@ fn collect_definitions(
             out(name, loc);
         }
     } else if DEFINITION_KINDS.contains(&node.kind()) {
-        if let Some(name) = extract_definition_name(node, lines) {
+        if lang == Lang::Verse && verse_skip_spurious_definition(node, lines) {
+            // fall through to children
+        } else if let Some(name) = extract_definition_name(node, lines) {
+            let start_line = node.start_position().row as u32 + 1;
+            let ast_end = node.end_position().row as u32 + 1;
+            let end_line = if lang == Lang::Verse {
+                verse_repair_end_line(node.kind(), start_line, ast_end, lines)
+            } else {
+                ast_end
+            };
             let loc = SymbolLocation {
                 path: path.to_path_buf(),
-                line: node.start_position().row as u32 + 1,
-                end_line: node.end_position().row as u32 + 1,
+                line: start_line,
+                end_line,
                 kind: node.kind().to_string(),
                 weight: definition_weight(node.kind()),
             };
@@ -416,5 +426,33 @@ mod tests {
         assert!(n >= 2, "expected class + function symbols, got {n}");
         assert_eq!(idx.lookup_exact("MyClass").len(), 1);
         assert_eq!(idx.lookup_exact("DoWork").len(), 1);
+    }
+
+    #[test]
+    fn verse_function_span_covers_if_guard_body() {
+        let f = touch_file(
+            "game_manager := class(creative_device):\n\
+             BindBaseComponentPlots<private>() : void =\n\
+                 if (Sim := GetGameSim[]):\n\
+                     Plot.SetPlayerBasesSlot(Idx)\n\
+                     Comp.BindPlot(Plot)\n\
+             OnBegin() : void = {}\n",
+            "verse",
+        );
+        let idx = SymbolIndex::new();
+        let mtime = std::fs::metadata(f.path()).unwrap().modified().unwrap();
+        idx.index_file(f.path(), mtime, &std::fs::read_to_string(f.path()).unwrap());
+        let hits = idx.lookup_exact("BindBaseComponentPlots");
+        assert_eq!(hits.len(), 1, "expected BindBaseComponentPlots definition");
+        assert!(
+            hits[0].end_line >= 5,
+            "expected span through body lines, got end_line {}",
+            hits[0].end_line
+        );
+        assert!(
+            hits[0].end_line < 6,
+            "should stop before sibling OnBegin, got end_line {}",
+            hits[0].end_line
+        );
     }
 }

--- a/crates/ffs-symbol/src/verse_spans.rs
+++ b/crates/ffs-symbol/src/verse_spans.rs
@@ -98,7 +98,7 @@ pub fn verse_skip_spurious_definition(node: Node, lines: &[&str]) -> bool {
     if name != "Categories" {
         return false;
     }
-    let line = node.start_position().row as usize;
+    let line = node.start_position().row;
     lines
         .get(line)
         .is_some_and(|l| l.contains("Categories := array{SettingsCategory}"))
@@ -141,7 +141,10 @@ mod tests {
             end >= 6,
             "expected body through nested if/for, got end_line {end}"
         );
-        assert!(end < 8, "should stop before sibling OnBegin at line 8, got {end}");
+        assert!(
+            end < 8,
+            "should stop before sibling OnBegin at line 8, got {end}"
+        );
     }
 
     #[test]
@@ -155,7 +158,10 @@ mod tests {
         let lines: Vec<&str> = src.lines().collect();
         let end = verse_repair_end_line("type_definition", 1, 1, &lines);
         assert!(end >= 4, "class should include members, got {end}");
-        assert!(end < 6, "should stop before module-level AddToTeam, got {end}");
+        assert!(
+            end < 6,
+            "should stop before module-level AddToTeam, got {end}"
+        );
     }
 
     #[test]

--- a/crates/ffs-symbol/src/verse_spans.rs
+++ b/crates/ffs-symbol/src/verse_spans.rs
@@ -54,6 +54,7 @@ pub fn verse_member_end_line(lines: &[&str], start_line: u32, ast_end: u32) -> u
 }
 
 /// Whether a Verse definition node likely needs span repair.
+#[cfg(test)]
 pub fn verse_should_repair_span(
     node_kind: &str,
     start_line: u32,
@@ -111,7 +112,10 @@ pub fn verse_repair_end_line(
     ast_end: u32,
     lines: &[&str],
 ) -> u32 {
-    if verse_should_repair_span(node_kind, start_line, ast_end, lines) {
+    if matches!(
+        node_kind,
+        "function_definition" | "extension_function_definition" | "type_definition"
+    ) {
         verse_member_end_line(lines, start_line, ast_end)
     } else {
         ast_end

--- a/crates/ffs-symbol/src/verse_spans.rs
+++ b/crates/ffs-symbol/src/verse_spans.rs
@@ -1,0 +1,168 @@
+//! Indentation-based span repair for Verse definitions whose tree-sitter
+//! `end_position` stops early.
+//!
+//! A common failure mode: `function_definition` gets an empty `indented_block`
+//! body while the real statements (`if_expression`, `for_expression`, …) parse
+//! as sibling class members at the same source lines. Symbol/callee/read tools
+//! key off `(start_line, end_line)`, so we extend the span through indented
+//! continuation lines.
+
+use tree_sitter::Node;
+
+use crate::treesitter::extract_definition_name;
+
+/// Column of the first non-whitespace character (tabs expand to 8 columns).
+pub fn line_indent(line: &str) -> u32 {
+    let mut col = 0u32;
+    for ch in line.chars() {
+        match ch {
+            ' ' => col += 1,
+            '\t' => col = (col + 8) & !7,
+            _ => break,
+        }
+    }
+    col
+}
+
+fn is_blank_or_comment(line: &str) -> bool {
+    let t = line.trim();
+    t.is_empty() || t.starts_with('#') || t.starts_with("<#")
+}
+
+/// Extend `[start_line, ast_end]` through lines indented deeper than the
+/// definition header. Stops at the first non-blank line whose indent is
+/// `<= base_indent` (a sibling member or module-level item).
+pub fn verse_member_end_line(lines: &[&str], start_line: u32, ast_end: u32) -> u32 {
+    let start_idx = start_line.saturating_sub(1) as usize;
+    if start_idx >= lines.len() {
+        return ast_end;
+    }
+    let base = line_indent(lines[start_idx]);
+    let mut end = ast_end.max(start_line);
+    for (idx, line) in lines.iter().enumerate().skip(start_idx + 1) {
+        if is_blank_or_comment(line) {
+            end = (idx as u32) + 1;
+            continue;
+        }
+        let indent = line_indent(line);
+        if indent <= base {
+            break;
+        }
+        end = (idx as u32) + 1;
+    }
+    end
+}
+
+/// Whether a Verse definition node likely needs span repair.
+pub fn verse_should_repair_span(
+    node_kind: &str,
+    start_line: u32,
+    ast_end: u32,
+    lines: &[&str],
+) -> bool {
+    if !matches!(
+        node_kind,
+        "function_definition" | "extension_function_definition" | "type_definition"
+    ) {
+        return false;
+    }
+    if ast_end <= start_line {
+        return true;
+    }
+    let start_idx = start_line.saturating_sub(1) as usize;
+    if start_idx >= lines.len() {
+        return false;
+    }
+    let base = line_indent(lines[start_idx]);
+    // Header-only span, or empty body with deeper-indented continuation.
+    if ast_end <= start_line + 1 {
+        let next_idx = ast_end as usize;
+        if next_idx < lines.len() {
+            let next = lines[next_idx];
+            if !is_blank_or_comment(next) && line_indent(next) > base {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Skip `@editable` metadata lines parsed as spurious `Categories` type defs.
+pub fn verse_skip_spurious_definition(node: Node, lines: &[&str]) -> bool {
+    if node.kind() != "type_definition" {
+        return false;
+    }
+    let Some(name) = extract_definition_name(node, lines) else {
+        return false;
+    };
+    if name != "Categories" {
+        return false;
+    }
+    let line = node.start_position().row as usize;
+    lines
+        .get(line)
+        .is_some_and(|l| l.contains("Categories := array{SettingsCategory}"))
+}
+
+/// Apply span repair when appropriate.
+pub fn verse_repair_end_line(
+    node_kind: &str,
+    start_line: u32,
+    ast_end: u32,
+    lines: &[&str],
+) -> u32 {
+    if verse_should_repair_span(node_kind, start_line, ast_end, lines) {
+        verse_member_end_line(lines, start_line, ast_end)
+    } else {
+        ast_end
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extends_if_guard_function_body() {
+        let src = r#"game_manager := class(creative_device):
+    BindBaseComponentPlots<private>() : void =
+        if (Sim := GetGameSim[]):
+            for (Idx -> Plot : PlayerBases):
+                Plot.SetPlayerBasesSlot(Idx)
+            if (Tz := TeleportZoneManager?):
+                Pad.BindTeleportManager(Tz)
+    OnBegin<override>()<suspends> : void =
+        BindBaseComponentPlots()
+"#;
+        let lines: Vec<&str> = src.lines().collect();
+        // Simulate truncated AST ending on the `if` header line (1-based line 3).
+        let end = verse_repair_end_line("function_definition", 2, 3, &lines);
+        assert!(
+            end >= 6,
+            "expected body through nested if/for, got end_line {end}"
+        );
+        assert!(end < 8, "should stop before sibling OnBegin at line 8, got {end}");
+    }
+
+    #[test]
+    fn extends_truncated_class_type_definition() {
+        let src = r#"game_manager := class(creative_device):
+    @editable
+    PetDevice : ?pet_device = false
+    OnBegin() : void = {}
+(Agent : agent).AddToTeam(T : int) : void = {}
+"#;
+        let lines: Vec<&str> = src.lines().collect();
+        let end = verse_repair_end_line("type_definition", 1, 1, &lines);
+        assert!(end >= 4, "class should include members, got {end}");
+        assert!(end < 6, "should stop before module-level AddToTeam, got {end}");
+    }
+
+    #[test]
+    fn leaves_short_function_untouched_when_ast_span_covers_body() {
+        let src = "Run():void=\n    Print(\"ok\")\n";
+        let lines: Vec<&str> = src.lines().collect();
+        let end = verse_repair_end_line("function_definition", 1, 2, &lines);
+        assert_eq!(end, 2);
+    }
+}

--- a/crates/ffs-symbol/src/verse_spans.rs
+++ b/crates/ffs-symbol/src/verse_spans.rs
@@ -53,41 +53,6 @@ pub fn verse_member_end_line(lines: &[&str], start_line: u32, ast_end: u32) -> u
     end
 }
 
-/// Whether a Verse definition node likely needs span repair.
-#[cfg(test)]
-pub fn verse_should_repair_span(
-    node_kind: &str,
-    start_line: u32,
-    ast_end: u32,
-    lines: &[&str],
-) -> bool {
-    if !matches!(
-        node_kind,
-        "function_definition" | "extension_function_definition" | "type_definition"
-    ) {
-        return false;
-    }
-    if ast_end <= start_line {
-        return true;
-    }
-    let start_idx = start_line.saturating_sub(1) as usize;
-    if start_idx >= lines.len() {
-        return false;
-    }
-    let base = line_indent(lines[start_idx]);
-    // Header-only span, or empty body with deeper-indented continuation.
-    if ast_end <= start_line + 1 {
-        let next_idx = ast_end as usize;
-        if next_idx < lines.len() {
-            let next = lines[next_idx];
-            if !is_blank_or_comment(next) && line_indent(next) > base {
-                return true;
-            }
-        }
-    }
-    false
-}
-
 /// Skip `@editable` metadata lines parsed as spurious `Categories` type defs.
 pub fn verse_skip_spurious_definition(node: Node, lines: &[&str]) -> bool {
     if node.kind() != "type_definition" {


### PR DESCRIPTION
## Summary

Fixes #55 — Verse tree-sitter often gives `function_definition` an **empty** `indented_block` body while the real `if`/`for` statements parse as **sibling** nodes on the following lines. ffs used the truncated AST `end_line`, which broke:

- `ffs read …:304` → "no structural section contains line"
- `ffs callees BindBaseComponentPlots` → empty
- `ffs flow BindBaseComponentPlots` → body stops at the `if` header

This PR adds indentation-based **span repair** for Verse `function_definition`, `extension_function_definition`, and `type_definition` when the AST span is header-only but deeper-indented continuation lines exist.

Also:
- Skip spurious `@editable` `Categories := array{SettingsCategory}` outline/symbol entries
- Collect `failable_call_expression` in callees (Verse `GetGameSim[]` style calls)

## Root cause (parser)

`tree-sitter parse game_manager.verse` shows:

```text
(function_definition [298, 4] - [299, 8]
  body: (indented_block [299, 8] - [299, 8]))   ;; empty
(if_expression [299, 8] - [309, 4]              ;; orphaned sibling
```

Span repair extends through lines indented deeper than the definition header until the next sibling at `<=` base indent.

## Test plan

- [x] `verse_spans` unit tests (if-guard body, truncated class, unchanged short fn)
- [x] `ffs-symbol` outline + symbol_index regression tests
- [x] `ffs-cli` callees Verse member-call test
- [ ] `cargo test -p ffs-symbol -p ffs-cli` (CI)
- [ ] Manual: `ffs flow BindBaseComponentPlots` on Chronicles `game_manager.verse` → callees include `BindPlot`, `GetGameSim`, …
